### PR TITLE
Fix missing import for encrypted DMs

### DIFF
--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -4,6 +4,7 @@ from app import app, error_response, get_cached_item, set_cached_item, initializ
 from pynostr.event import Event, EventKind
 from pynostr.filters import Filters, FiltersList
 from pynostr.key import PrivateKey
+from pynostr.encrypted_dm import EncryptedDirectMessage
 
 def require_nip05_verification(required_domain):
     from functools import wraps


### PR DESCRIPTION
## Summary
- add `EncryptedDirectMessage` import so `_send_dm` can create encrypted messages

## Testing
- `python -m py_compile nostr_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687131a06e848327b8c142cfcad19ab5