### PR TITLE
Fix directory name in file tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Set the following environment variables to configure the application:
 ## File Structure
 
 ```
-fuzzedrecords/
+fuzzedrecords-web/
 ├── app.py                    # Top-level Flask router (imports modular routes)
 ├── azure_resources.py        # MSAL & Nostr discovery JSON endpoint
 ├── nostr_utils.py            # Nostr endpoints: /fetch-profile, /validate-profile, events


### PR DESCRIPTION
## Summary
- fix the top directory name in the README file structure section

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687137f9fe7c8327998431bdc2130798