### PR TITLE
Fix (#Nostr) typo in profile instructions

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -42,7 +42,7 @@
             <div id="profile-container">
                 <div>
                     <p class="empty-profile">
-                        No profile information available. Please authenticate with a (#Nostr) NIP-07 capable wallet such as 
+                        No profile information available. Please authenticate with a Nostr NIP-07 capable wallet such as
                         <a href="https://getalby.com/products/browser-extension" target="_blank"
                             rel="noopener noreferrer">
                             <img src="/static/images/thumb_Alby-logo-figure-400.png" alt="Alby Logo"


### PR DESCRIPTION
## Summary
- correct the text that instructs users how to authenticate in `index.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687120a28b7483279a2aef1e72d3eb1e