### PR TITLE
Fix README root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Set the following environment variables to configure the application:
 ## File Structure
 
 ```
-fuzzedrecords-web/
+./
 ├── app.py                    # Top-level Flask router (imports modular routes)
 ├── azure_resources.py        # MSAL & Nostr discovery JSON endpoint
 ├── nostr_utils.py            # Nostr endpoints: /fetch-profile, /validate-profile, events


### PR DESCRIPTION
## Summary
- fix the root folder name in the File Structure tree

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871dd0b29608327a4023da801430460