### PR TITLE
Extend profile fetch wait time

### DIFF
--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -46,7 +46,7 @@ async def fetch_profile():
     filt = FiltersList([Filters(authors=[pubkey_hex], kinds=[EventKind.SET_METADATA], limit=1)])
     mgr.add_subscription_on_all_relays(f"fetch_{pubkey_hex}", filt)
     logger.debug("Awaiting profile event for pubkey %s", pubkey_hex)
-    await asyncio.sleep(2)
+    await asyncio.sleep(60)
     profile_data = {}
     for msg in mgr.message_pool.get_all_events():
         ev = msg.event


### PR DESCRIPTION
## Summary
- wait up to 60 seconds for profile metadata from relays

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e028c2a483279e198c846205b9a0