### PR TITLE
Add Nostr relay connectivity test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ qrcode==7.4.2
 gunicorn>=20.1.0
 azure-data-tables>=12.6.0
 pytest>=7.4
+websockets>=15.0

--- a/tests/test_nostr_connection.py
+++ b/tests/test_nostr_connection.py
@@ -1,0 +1,47 @@
+import asyncio
+import json
+import websockets
+
+async def try_connect(url="wss://relay.damus.io"):
+    """Open a WebSocket connection to the given relay."""
+    try:
+        async with websockets.connect(url, open_timeout=5):
+            print("connected")
+            return True
+    except Exception as e:
+        print(e)
+        return False
+
+
+async def fetch_profile(pubkey: str, url: str = "wss://relay.damus.io"):
+    """Fetch a Nostr metadata event for ``pubkey`` from ``url``."""
+    try:
+        async with websockets.connect(url, open_timeout=5) as ws:
+            req_id = "profile_test"
+            req = ["REQ", req_id, {"kinds": [0], "authors": [pubkey], "limit": 1}]
+            await ws.send(json.dumps(req))
+            while True:
+                try:
+                    msg = await asyncio.wait_for(ws.recv(), timeout=5)
+                except asyncio.TimeoutError:
+                    break
+                data = json.loads(msg)
+                if data[0] == "EVENT" and data[1] == req_id:
+                    return json.loads(data[2].get("content", "{}"))
+                if data[0] == "EOSE" and data[1] == req_id:
+                    break
+    except Exception as e:
+        print(e)
+    return None
+
+def test_nostr_relay_connection():
+    assert isinstance(asyncio.run(try_connect()), bool)
+
+
+def test_fetch_profile():
+    pubkey = "00202dff6f2ab427ff6741817de6f61a5a15f57e62ae77d12b209590de32ad2f038b"
+    profile = asyncio.run(fetch_profile(pubkey))
+    # The relay may not have the profile cached, but if it does, it should be a dict
+    assert profile is None or isinstance(profile, dict)
+
+


### PR DESCRIPTION
## Summary
- add `websockets` dependency
- create `test_nostr_connection.py` to exercise a websocket connection to a public Nostr relay
- add profile fetch test for pubkey `00202dff6f2ab427ff6741817de6f61a5a15f57e62ae77d12b209590de32ad2f038b`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b5dd6d7a8832791ed42f9255ac1fd