### PR TITLE
Reduce profile fetch wait

### DIFF
--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -46,7 +46,7 @@ async def fetch_profile():
     filt = FiltersList([Filters(authors=[pubkey_hex], kinds=[EventKind.SET_METADATA], limit=1)])
     mgr.add_subscription_on_all_relays(f"fetch_{pubkey_hex}", filt)
     logger.debug("Awaiting profile event for pubkey %s", pubkey_hex)
-    await asyncio.sleep(60)
+    await asyncio.sleep(5)
     profile_data = {}
     for msg in mgr.message_pool.get_all_events():
         ev = msg.event


### PR DESCRIPTION
## Summary
- shorten the wait in `fetch_profile` so Gunicorn workers don't time out

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ba871309883278612e0059ada5c5c