### PR TITLE
Handle relay connection failures in profile fetch

### DIFF
--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -43,6 +43,11 @@ async def fetch_profile():
         logger.debug("RelayManager connections prepared")
     except Exception as e:
         logger.error("Error preparing relay connections: %s", e)
+
+    statuses = getattr(mgr, "connection_statuses", {})
+    if statuses and not any(statuses.values()):
+        logger.error("Unable to connect to any Nostr relays: %s", statuses)
+        return error_response("Unable to connect to Nostr relays", 503)
     filt = FiltersList([Filters(authors=[pubkey_hex], kinds=[EventKind.SET_METADATA], limit=1)])
     mgr.add_subscription_on_all_relays(f"fetch_{pubkey_hex}", filt)
     logger.debug("Awaiting profile event for pubkey %s", pubkey_hex)

--- a/tests/test_fetch_profile_fail.py
+++ b/tests/test_fetch_profile_fail.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import nostr_utils
+from app import app
+
+class DummyMgr:
+    async def prepare_relays(self):
+        pass
+    @property
+    def connection_statuses(self):
+        return {"r1": False, "r2": False}
+
+def test_fetch_profile_returns_503(monkeypatch):
+    monkeypatch.setattr(nostr_utils, "initialize_client", lambda: DummyMgr())
+    with app.test_client() as client:
+        resp = client.post("/fetch-profile", json={"pubkey": "abc"})
+        assert resp.status_code == 503
+        assert resp.get_json()["error"] == "Unable to connect to Nostr relays"


### PR DESCRIPTION
## Summary
- error out from `fetch_profile` when all relays fail
- test new behaviour when connection status is all false

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb61cc3c08327a3de1f24135ac89e