### PR TITLE
Update README with relay connection note

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Set the following environment variables to configure the application:
      ```
    - `startup.sh` installs Python dependencies and then launches the server.
    - Deploy the app to Azure WebApp using the Azure CLI or portal.
+    > **Note**: The application must be able to establish outbound WebSocket connections to the relays listed in `RELAY_URLS`. Blocked outbound traffic will result in profile fetch failures.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that outbound WebSocket connections must be allowed to relays in `RELAY_URLS`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb854f1048327858c40377192e4fa