### PR TITLE
Add gear menu and intro logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify, render_template, send_from_directory
+from flask import Flask, jsonify, render_template, send_from_directory, redirect
 from flask_restful import Api
 # CORS configuration
 from flask_cors import CORS
@@ -121,6 +121,10 @@ register_ticket_routes(app)
 @app.route('/')
 def index():
     return render_template('index.html')
+
+@app.route('/', subdomain='fuzzedguitars')
+def guitars_redirect():
+    return redirect('https://fuzzedrecords.com/#gear', code=301)
     
 # Health check for uptime probes (e.g. random /robotsXYZ.txt)
 @app.route('/robots<filename>.txt')

--- a/static/scripts/auth.js
+++ b/static/scripts/auth.js
@@ -5,6 +5,20 @@ import { showSection } from './utils.js';
 // Global profile state
 let userProfile = null;
 
+async function validateProfile(pubkey) {
+  try {
+    const resp = await fetch('/validate-profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pubkey })
+    });
+    return resp.ok;
+  } catch (err) {
+    console.error('Validation error:', err);
+    return false;
+  }
+}
+
 // Display user profile details
 export function displayProfile(profileData) {
   const profileContainer = document.getElementById('profile-container');
@@ -74,6 +88,11 @@ export async function authenticateWithNostr() {
     }
     userProfile = profileData;
     displayProfile(profileData);
+    const valid = await validateProfile(pubkey);
+    const introEl = document.getElementById('intro-section');
+    if (introEl) {
+      introEl.style.display = valid ? 'none' : 'block';
+    }
   } catch (err) {
     console.error('Authentication error:', err);
   }
@@ -83,18 +102,8 @@ export async function authenticateWithNostr() {
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('menu-library')
     .addEventListener('click', () => showSection('library'));
-  document.getElementById('menu-profile')
-    .addEventListener('click', async () => {
-      const btn = document.getElementById('menu-profile');
-      btn.textContent = 'Signing in...';
-      await authenticateWithNostr();
-      btn.textContent = 'Profile';
-      document.getElementById('menu-events').style.display = 'inline-block';
-      showSection('profile');
-    });
-});
-
-document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('menu-gear')
+    .addEventListener('click', () => showSection('gear'));
   const menuProfile = document.getElementById('menu-profile');
   menuProfile.addEventListener('click', async () => {
     if (!menuProfile.dataset.loggedIn) {
@@ -102,6 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
       await authenticateWithNostr();
       menuProfile.textContent = 'Profile';
       document.getElementById('menu-events').style.display = 'inline-block';
+      menuProfile.dataset.loggedIn = 'true';
     }
     showSection('profile');
   });

--- a/static/scripts/events.js
+++ b/static/scripts/events.js
@@ -5,11 +5,15 @@ import { showSection, getTagValue } from './utils.js';
 // Fetch and display fuzzed events
 export async function fetchFuzzedEvents() {
   const container = document.getElementById('events-section-content');
+  const registerBtn = document.getElementById('register-btn');
   container.innerHTML = '';
   try {
     const response = await fetch('/fuzzed_events');
     const data = await response.json();
     if (data.events && data.events.length > 0) {
+      if (registerBtn && localStorage.getItem('pubkey')) {
+        registerBtn.style.display = 'inline-block';
+      }
       data.events.forEach(ev => {
         const el = document.createElement('div');
         el.classList.add('event-item');
@@ -24,10 +28,12 @@ export async function fetchFuzzedEvents() {
         container.appendChild(el);
       });
     } else {
+      if (registerBtn) registerBtn.style.display = 'none';
       container.innerHTML = '<p>No events available.</p>';
     }
   } catch (err) {
     console.error('Error fetching events:', err);
+    if (registerBtn) registerBtn.style.display = 'none';
     container.innerHTML = '<p>Error loading events.</p>';
   }
 }

--- a/static/scripts/utils.js
+++ b/static/scripts/utils.js
@@ -1,7 +1,7 @@
 // utils.js - shared helper functions
 // Switch between content sections
 export function showSection(section) {
-  const sections = ['library', 'profile', 'events', 'admin'];
+  const sections = ['library', 'profile', 'events', 'admin', 'gear'];
   sections.forEach(sec => {
     const el = document.getElementById(`${sec}-section`);
     const btn = document.getElementById(`menu-${sec}`);

--- a/static/style.css
+++ b/static/style.css
@@ -59,7 +59,8 @@ body {
 #library-section,
 #profile-section,
 #events-section,
-#admin-section {
+#admin-section,
+#gear-section {
     display: none;
     padding: 20px;
 }
@@ -67,7 +68,8 @@ body {
 #library-section.active,
 #profile-section.active,
 #events-section.active,
-#admin-section.active {
+#admin-section.active,
+#gear-section.active {
     display: block;
 }
 
@@ -185,4 +187,23 @@ footer {
     margin-top: 20px;
     color: #777;
     font-size: 14px;
+}
+
+/* Intro and gear styling */
+#intro-section {
+    padding: 20px;
+}
+.gear-logo {
+    max-width: 200px;
+    width: 80%;
+    height: auto;
+    margin: 10px auto;
+    display: block;
+}
+.gear-photo {
+    max-width: 300px;
+    width: 90%;
+    height: auto;
+    margin: 10px auto;
+    display: block;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
 
     <nav class="menu">
         <button id="menu-library" class="nav-btn active">Library</button>
+        <button id="menu-gear" class="nav-btn">Gear</button>
         <!-- Profile button is always visible so the user can trigger login -->
         <button id="menu-profile" class="nav-btn">Nostr Login</button>
         <!-- Events and Admin remain hidden until authentication -->
@@ -24,6 +25,11 @@
     </nav>
 
     <main>
+        <section id="intro-section" class="content-section">
+            <p class="intro-welcome">Welcome to Fuzzed Records!</p>
+            <p class="intro-text">Fuzzed Records is a Nostr-enabled independent label and gear lab. Explore identity, music, and experiments in analog and digital sound.</p>
+        </section>
+
         <section id="library-section" class="content-section active">
             <h2>
                 Songs in our Library at:
@@ -35,6 +41,20 @@
             <div id="songs-section">
                 <p>Loading songs...</p>
             </div>
+        </section>
+
+        <section id="gear-section" class="content-section">
+            <h2>Fuzzed Guitars</h2>
+            <img src="/static/images/fuzzed-guitars-logo.jfif" alt="Fuzzed Guitars Logo" class="gear-logo">
+            <p>Boutique gear crafted for experimental sound.</p>
+            <img src="/static/images/lasered-fuzzed-guitars.jfif" alt="Fuzzed Guitars" class="gear-photo">
+            <p class="coming-soon">Guitar and pedal prototypes coming soon.</p>
+        </section>
+
+        <section id="events" class="content-section">
+            <h2>Events</h2>
+            <p>Live events and demos coming soon.</p>
+            <button id="register-btn" style="display: none;">Register</button>
         </section>
 
         <section id="profile-section">


### PR DESCRIPTION
## Summary
- add a short intro about the site
- introduce Gear section with placeholder images
- show events placeholder and register button logic
- hide the intro after a valid profile is loaded
- allow redirect for fuzzedguitars.com subdomain

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688420db299083279a796e89a70edd6d