### PR TITLE
Update logo when viewing gear

### DIFF
--- a/static/scripts/utils.js
+++ b/static/scripts/utils.js
@@ -8,6 +8,14 @@ export function showSection(section) {
     if (el) el.classList.toggle('active', sec === section);
     if (btn) btn.classList.toggle('active', sec === section);
   });
+  const logo = document.getElementById('header-logo');
+  if (logo) {
+    if (section === 'gear') {
+      logo.src = '/static/images/fuzzed-guitars-logo.jfif';
+    } else {
+      logo.src = '/static/images/fuzzedrecords.png';
+    }
+  }
 }
 
 // Extract single-letter tag value from event tags

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
 
 <body>
     <header>
-        <img src="/static/images/fuzzedrecords.png" alt="Fuzzed Records Logo" class="logo">
+        <img id="header-logo" src="/static/images/fuzzedrecords.png" alt="Fuzzed Records Logo" class="logo">
     </header>
 
     <nav class="menu">


### PR DESCRIPTION
## Summary
- swap the header logo to the Fuzzed Guitars logo on the Gear section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884270b8fa08327826bbc9be98899e3