### PR TITLE
Style intro box and remove gear logo

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -192,13 +192,13 @@ footer {
 /* Intro and gear styling */
 #intro-section {
     padding: 20px;
-}
-.gear-logo {
-    max-width: 200px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    max-width: 500px;
     width: 80%;
-    height: auto;
-    margin: 10px auto;
-    display: block;
+    margin: 20px auto;
+    background: #f9f9f9;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.2);
 }
 .gear-photo {
     max-width: 300px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,7 +45,6 @@
 
         <section id="gear-section" class="content-section">
             <h2>Fuzzed Guitars</h2>
-            <img src="/static/images/fuzzed-guitars-logo.jfif" alt="Fuzzed Guitars Logo" class="gear-logo">
             <p>Boutique gear crafted for experimental sound.</p>
             <img src="/static/images/lasered-fuzzed-guitars.jfif" alt="Fuzzed Guitars" class="gear-photo">
             <p class="coming-soon">Guitar and pedal prototypes coming soon.</p>


### PR DESCRIPTION
## Summary
- remove gear logo from gear section
- add bordered box styling to intro section matching menu width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688429db8e248327bb2c3540667af48e