### PR TITLE
Trim blank space around logos

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6,12 +6,19 @@ body {
     overflow-x: hidden; /* Prevent horizontal scrolling on mobile */
 }
 
+.logo-container {
+    max-width: 500px;
+    width: 80%;
+    height: 220px;
+    margin: 20px auto;
+    overflow: hidden;
+}
+
 .logo {
     display: block;
-    max-width: 500px;
-    width: 80%; /* Maintain responsiveness */
-    margin: 20px auto;
-    height: auto; /* Maintain aspect ratio */
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .menu {
@@ -200,10 +207,18 @@ footer {
     background: #f9f9f9;
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.2);
 }
-.gear-photo {
+
+.gear-container {
     max-width: 300px;
     width: 90%;
-    height: auto;
+    height: 200px;
     margin: 10px auto;
+    overflow: hidden;
+}
+
+.gear-photo {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
     display: block;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,9 @@
 
 <body>
     <header>
-        <img id="header-logo" src="/static/images/fuzzedrecords.png" alt="Fuzzed Records Logo" class="logo">
+        <div class="logo-container">
+            <img id="header-logo" src="/static/images/fuzzedrecords.png" alt="Fuzzed Records Logo" class="logo">
+        </div>
     </header>
 
     <nav class="menu">
@@ -45,7 +47,9 @@
 
         <section id="gear-section" class="content-section">
             <p>Boutique gear crafted for experimental sound.</p>
-            <img src="/static/images/lasered-fuzzed-guitars.jfif" alt="Fuzzed Guitars" class="gear-photo">
+            <div class="gear-container">
+                <img src="/static/images/lasered-fuzzed-guitars.jfif" alt="Fuzzed Guitars" class="gear-photo">
+            </div>
             <p class="coming-soon">Guitar and pedal prototypes coming soon.</p>
         </section>
 


### PR DESCRIPTION
## Summary
- wrap logos in containers to crop blank space
- style new containers with `overflow:hidden` and `object-fit:cover`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68842f8ba49c83278f34b4320b573991