### PR TITLE
Enable hash based section navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Fuzzed Records is a modern music platform that integrates decentralized authenti
 - **Responsive Design**: Optimized for both desktop and mobile devices.
 - **QR Code Ticketing**: Generate QR code tickets for live music events, sent via Nostr DM to users.
 - **Efficient Data Caching**: Utilizes caching for optimizing data retrieval performance.
+- **Section Links**: Use URL hashes like `/#gear` to open a specific section directly.
 
 ---
 

--- a/static/scripts/auth.js
+++ b/static/scripts/auth.js
@@ -111,4 +111,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     showSection('profile');
   });
+
+  // Allow linking directly to a section via URL hash (e.g., /#gear)
+  const hash = window.location.hash.replace('#', '');
+  const sections = ['library', 'profile', 'events', 'admin', 'gear'];
+  if (sections.includes(hash)) {
+    showSection(hash);
+  }
 });


### PR DESCRIPTION
## Summary
- support linking directly to a section via URL hash
- note section hash links in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688437e40b888327838b95dcc11625ff