### PR TITLE
Add nprofile to login profile info

### DIFF
--- a/static/scripts/auth.js
+++ b/static/scripts/auth.js
@@ -34,8 +34,9 @@ export function displayProfile(profileData) {
   }
   const detailsTable = document.createElement('table');
   detailsTable.classList.add('profile-details');
-  // Always show pubkey; then any other profile details
+  // Always show nprofile and pubkey; then any other profile details
   const details = [
+    { label: 'Nprofile', value: profileData.nprofile },
     { label: 'Pubkey', value: pubkey },
     { label: 'Username', value: content.name },
     { label: 'NIP-05', value: content.nip05 },


### PR DESCRIPTION
## Summary
- fix nprofile decoder import and use utils helpers
- expose nprofile on `/fetch-profile`
- display nprofile in the frontend profile view

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884429b587c832789f88ce0bd4f87dc