### PR TITLE
Fix nprofile fetch with nip19 fallback

### DIFF
--- a/tests/test_fetch_nprofile.py
+++ b/tests/test_fetch_nprofile.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+from app import app
+from pynostr.utils import nprofile_encode
+
+
+def test_fetch_nprofile_fallback(monkeypatch):
+    pubkey = "00" * 32
+    nprof = nprofile_encode(pubkey, ["wss://relay.example.com"])
+
+    monkeypatch.setattr(app_module, "fetch_profile_by_pubkey", lambda p, r: {"name": "x"})
+
+    with app.test_client() as client:
+        resp = client.post("/fetch-nprofile", json={"nprofile": nprof})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["pubkey"] == pubkey
+        assert data["metadata"] == {"name": "x"}


### PR DESCRIPTION
## Summary
- add a robust nip19 decode fallback when pynostr doesn't provide one
- simplify fetch-nprofile to rely on nip19_decode
- test nprofile endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ffec6cb08327812811ee22016d0d