### PR TITLE
Handle spaces in relay URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,10 +84,13 @@ limiter = Limiter(
 api = Api(app)
 
 # Configuration
-RELAY_URLS = os.getenv(
-    "RELAY_URLS",
-    "wss://relay.damus.io,wss://relay.primal.net,wss://relay.mostr.pub"
-).split(',')
+RELAY_URLS = [
+    u.strip()
+    for u in os.getenv(
+        "RELAY_URLS",
+        "wss://relay.damus.io,wss://relay.primal.net,wss://relay.mostr.pub",
+    ).split(",")
+]
 CACHE_TIMEOUT = int(os.getenv("CACHE_TIMEOUT", 300))
 REQUIRED_DOMAIN = os.getenv("REQUIRED_DOMAIN", "fuzzedrecords.com")
 # Base URL for Wavlake API; can be overridden via environment

--- a/tests/test_relay_urls.py
+++ b/tests/test_relay_urls.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import importlib
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+
+
+def test_relay_urls_strip(monkeypatch):
+    original = os.environ.get("RELAY_URLS")
+    monkeypatch.setenv("RELAY_URLS", "wss://a.com, wss://b.com")
+    importlib.reload(app_module)
+    assert app_module.RELAY_URLS == ["wss://a.com", "wss://b.com"]
+    if original is not None:
+        monkeypatch.setenv("RELAY_URLS", original)
+    else:
+        monkeypatch.delenv("RELAY_URLS", raising=False)
+    importlib.reload(app_module)


### PR DESCRIPTION
## Summary
- trim spaces from `RELAY_URLS` entries
- add regression test for parsing relay URLs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688577915b24832781117ffb0886385c