### PR TITLE
Add dynamic relay list management

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Set the following environment variables to configure the application:
     > **Note**: The application must be able to establish outbound WebSocket connections to the relays listed in `RELAY_URLS`. Blocked outbound traffic will result in profile fetch failures.
 7. **Maintain Relay Lists**:
    - Run `python relay_checker.py` periodically to update `good-relays.txt`.
-   - Users can contribute relays via the `/update-relays` endpoint when logging in.
+   - On startup the app loads relays from `good-relays.txt` if present, falling back to `relays.txt` or the `RELAY_URLS` environment variable.
+   - Users can contribute relays via the `/update-relays` endpoint; submitted URLs are merged in-memory and written back to `relays.txt`.
 
 ---
 
@@ -258,7 +259,7 @@ Set the following environment variables to configure the application:
 ### 8. Update Relays
 - **Endpoint**: `/update-relays`
 - **Method**: `POST`
-- **Description**: Appends relay URLs to `relays.txt`.
+- **Description**: Merges relay URLs into the active list and persists them to `relays.txt`.
 - **Request Body**:
   ```json
   {"relays": ["wss://relay1", "wss://relay2"]}

--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -1,6 +1,6 @@
 import os, json, time, asyncio, logging
 from flask import request, jsonify
-from app import app, error_response, get_cached_item, set_cached_item, initialize_client, logger, REQUIRED_DOMAIN, RELAY_URLS
+from app import app, error_response, get_cached_item, set_cached_item, initialize_client, logger, REQUIRED_DOMAIN, ACTIVE_RELAYS
 try:
     from pynostr.utils import nprofile_encode
 except Exception:  # pragma: no cover - fallback if module missing
@@ -42,7 +42,8 @@ async def fetch_profile():
 
     nprof = None
     try:
-        nprof = nprofile_encode(pubkey_hex, RELAY_URLS)
+        from app import ACTIVE_RELAYS
+        nprof = nprofile_encode(pubkey_hex, ACTIVE_RELAYS)
     except Exception as e:
         logger.warning("nprofile encode failed: %s", e)
     mgr = initialize_client()

--- a/tests/test_update_relays.py
+++ b/tests/test_update_relays.py
@@ -1,0 +1,21 @@
+import os, sys, importlib
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+def test_update_relays_updates_state(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RELAY_URLS", "wss://a.com")
+    import app as app_module
+    importlib.reload(app_module)
+
+    with app_module.app.test_client() as client:
+        resp = client.post("/update-relays", json={"relays": ["wss://b.com"]})
+        assert resp.status_code == 200
+        assert set(app_module.ACTIVE_RELAYS) == {"wss://a.com", "wss://b.com"}
+        with open("relays.txt") as f:
+            lines = {l.strip() for l in f if l.strip()}
+        assert lines == {"wss://a.com", "wss://b.com"}
+        mgr = app_module.initialize_client()
+        assert set(mgr.relays.keys()) == {"wss://a.com", "wss://b.com"}
+


### PR DESCRIPTION
## Summary
- manage active relay list dynamically
- write new helper `load_relays_from_file`
- keep active list in memory and update `/update-relays`
- use the active list when creating Nostr clients and nprofiles
- document the behaviour
- test update-relays logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885865ccdec832781c2407522acc743