### PR TITLE
Fix relay fallback logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Fuzzed Records is a modern music platform that integrates decentralized authenti
 
 Set the following environment variables to configure the application:
 
-- RELAY_URLS: Comma-separated list of Nostr relay URLs (default: wss://relay.damus.io,wss://relay.primal.net,wss://relay.mostr.pub,wss://nos.lol)
+- RELAY_URLS: Comma-separated list of Nostr relay URLs (default: wss://relay.damus.io,wss://relay.primal.net,wss://relay.mostr.pub,wss://nos.lol). If unset and no relay list files exist, this default list populates `ACTIVE_RELAYS`.
 - CACHE_TIMEOUT: Seconds to cache fetched user profiles (default: 300)
 - REQUIRED_DOMAIN: Domain for NIP-05 profile verification (default: fuzzedrecords.com)
 - MAX_CONTENT_LENGTH: Max request payload size in bytes (default: 1048576)

--- a/app.py
+++ b/app.py
@@ -115,7 +115,12 @@ def load_relays_from_file():
                 rels = [l.strip() for l in f if l.strip()]
             if rels:
                 return rels
-    return [u.strip() for u in os.getenv("RELAY_URLS", "").split(",") if u.strip()]
+    # Fallback to the module constant if the environment variable isn't set
+    return [
+        u.strip()
+        for u in os.getenv("RELAY_URLS", ",".join(RELAY_URLS)).split(",")
+        if u.strip()
+    ]
 
 # Initialize at startup
 ACTIVE_RELAYS = load_relays_from_file()

--- a/tests/test_relay_urls.py
+++ b/tests/test_relay_urls.py
@@ -17,3 +17,17 @@ def test_relay_urls_strip(monkeypatch):
     else:
         monkeypatch.delenv("RELAY_URLS", raising=False)
     importlib.reload(app_module)
+
+
+def test_active_relays_default(monkeypatch, tmp_path):
+    """ACTIVE_RELAYS should fall back to the default list when no files or env."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("RELAY_URLS", raising=False)
+    importlib.reload(app_module)
+
+    assert app_module.ACTIVE_RELAYS == [
+        "wss://relay.damus.io",
+        "wss://relay.primal.net",
+        "wss://relay.mostr.pub",
+        "wss://nos.lol",
+    ]


### PR DESCRIPTION
## Summary
- load default relays when RELAY_URLS env var is unset
- test default ACTIVE_RELAYS behavior
- clarify RELAY_URLS fallback behavior in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858b93edac8327b76abe704f7ef72c