### PR TITLE
Add profile fetch timeout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Set the following environment variables to configure the application:
 - HTTP_TIMEOUT: Timeout in seconds for each Wavlake API request (default: 5)
 - TRACK_CACHE_TIMEOUT: Seconds to cache the music library before background refresh (default: 300)
 - SEARCH_TERM: Search term used to filter Wavlake artists (default: " by Fuzzed Records")
+- PROFILE_FETCH_TIMEOUT: Seconds to wait for a user profile event when handling `/fetch-profile` or `/validate-profile` (default: 5)
 - TENANT_ID: Azure AD Tenant ID for discovery JSON endpoint (/.well-known/nostr.json)
 - CLIENT_ID: Azure AD Application (client) ID
 - CLIENT_SECRET: Azure AD Application client secret

--- a/app.py
+++ b/app.py
@@ -99,6 +99,7 @@ REQUIRED_DOMAIN = os.getenv("REQUIRED_DOMAIN", "fuzzedrecords.com")
 # Default updated to use wavlake.com domain as per API docs
 WAVLAKE_API_BASE = os.getenv("WAVLAKE_API_BASE", "https://wavlake.com/api/v1")
 SEARCH_TERM = " by Fuzzed Records"
+PROFILE_FETCH_TIMEOUT = float(os.getenv("PROFILE_FETCH_TIMEOUT", "5"))
 
 # Logging setup
 logging.basicConfig(level=os.getenv('LOG_LEVEL', 'DEBUG'))

--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -1,6 +1,6 @@
 import os, json, time, asyncio, logging
 from flask import request, jsonify
-from app import app, error_response, get_cached_item, set_cached_item, initialize_client, logger, REQUIRED_DOMAIN, ACTIVE_RELAYS
+from app import app, error_response, get_cached_item, set_cached_item, initialize_client, logger, REQUIRED_DOMAIN, ACTIVE_RELAYS, PROFILE_FETCH_TIMEOUT
 try:
     from pynostr.utils import nprofile_encode
 except Exception:  # pragma: no cover - fallback if module missing
@@ -79,7 +79,7 @@ async def fetch_profile():
             await asyncio.sleep(0.05)
 
     try:
-        msg_type, msg = await asyncio.wait_for(wait_for_message(), timeout=5)
+        msg_type, msg = await asyncio.wait_for(wait_for_message(), timeout=PROFILE_FETCH_TIMEOUT)
     except asyncio.TimeoutError:
         logger.warning("Timeout waiting for profile event for %s", pubkey_hex)
         mgr.close_connections()


### PR DESCRIPTION
## Summary
- allow configuring the timeout when waiting for profile events
- use the new setting in `nostr_utils`
- document `PROFILE_FETCH_TIMEOUT`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885938aabc88327829ce2ae172b795c