### PR TITLE
Add configurable relay connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Set the following environment variables to configure the application:
 - TRACK_CACHE_TIMEOUT: Seconds to cache the music library before background refresh (default: 300)
 - SEARCH_TERM: Search term used to filter Wavlake artists (default: " by Fuzzed Records")
 - PROFILE_FETCH_TIMEOUT: Seconds to wait for a user profile event when handling `/fetch-profile` or `/validate-profile` (default: 5)
+- RELAY_CONNECT_TIMEOUT: Seconds allowed to establish each WebSocket connection to a relay (default: 2)
 - TENANT_ID: Azure AD Tenant ID for discovery JSON endpoint (/.well-known/nostr.json)
 - CLIENT_ID: Azure AD Application (client) ID
 - CLIENT_SECRET: Azure AD Application client secret

--- a/app.py
+++ b/app.py
@@ -100,6 +100,7 @@ REQUIRED_DOMAIN = os.getenv("REQUIRED_DOMAIN", "fuzzedrecords.com")
 WAVLAKE_API_BASE = os.getenv("WAVLAKE_API_BASE", "https://wavlake.com/api/v1")
 SEARCH_TERM = " by Fuzzed Records"
 PROFILE_FETCH_TIMEOUT = float(os.getenv("PROFILE_FETCH_TIMEOUT", "5"))
+RELAY_CONNECT_TIMEOUT = float(os.getenv("RELAY_CONNECT_TIMEOUT", "2"))
 
 # Logging setup
 logging.basicConfig(level=os.getenv('LOG_LEVEL', 'DEBUG'))
@@ -151,7 +152,7 @@ def error_response(message, status_code):
 
 def initialize_client():
     # Initialize Nostr RelayManager and add configured relays
-    mgr = RelayManager()
+    mgr = RelayManager(timeout=RELAY_CONNECT_TIMEOUT)
     for url in ACTIVE_RELAYS:
         mgr.add_relay(url)
     return mgr

--- a/tests/test_relay_connect_timeout.py
+++ b/tests/test_relay_connect_timeout.py
@@ -1,0 +1,13 @@
+import os, sys, importlib
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+def test_relay_connect_timeout_env(monkeypatch):
+    monkeypatch.setenv("RELAY_CONNECT_TIMEOUT", "6")
+    import app as app_module
+    importlib.reload(app_module)
+
+    assert app_module.RELAY_CONNECT_TIMEOUT == 6.0
+    mgr = app_module.initialize_client()
+    assert all(r.timeout == 6.0 for r in mgr.relays.values())


### PR DESCRIPTION
## Summary
- allow customizing connection timeout with `RELAY_CONNECT_TIMEOUT`
- document the new variable
- test that relays honor `RELAY_CONNECT_TIMEOUT`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888db1356348327bcf45d40165aa08e