### PR TITLE
Fix websockets SSL parameter for wss URLs

### DIFF
--- a/nostr_client.py
+++ b/nostr_client.py
@@ -165,7 +165,15 @@ class RelayManager:
 
     async def _connect(self, relay: _Relay, ssl_ctx):
         try:
-            relay.ws = await websockets.connect(relay.url, open_timeout=self.timeout, ssl=ssl_ctx)
+            if relay.url.startswith("wss://"):
+                ssl_param = ssl_ctx if ssl_ctx is not None else True
+            else:
+                ssl_param = None
+            relay.ws = await websockets.connect(
+                relay.url,
+                open_timeout=self.timeout,
+                ssl=ssl_param,
+            )
             self.connection_statuses[relay.url] = True
             asyncio.create_task(self._recv_loop(relay))
         except Exception as exc:


### PR DESCRIPTION
## Summary
- ensure RelayManager passes an appropriate `ssl` parameter to `websockets.connect`
- this prevents runtime errors like `ssl=None is incompatible with a wss:// URI`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68890bb301888327b05d7306422478c6