### PR TITLE
Update profile UI and relays

### DIFF
--- a/good-relays.txt
+++ b/good-relays.txt
@@ -6,4 +6,3 @@ wss://relay.getalby.com/v1
 wss://relay.nostr.band/
 wss://relay.noswhere.com/
 wss://relay.primal.net/
-wss://relay.snort.social/

--- a/static/scripts/auth.js
+++ b/static/scripts/auth.js
@@ -52,10 +52,8 @@ export function displayProfile(profileData) {
   }
   const detailsTable = document.createElement('table');
   detailsTable.classList.add('profile-details');
-  // Always show nprofile and pubkey; then any other profile details
+  // Display profile fields other than nprofile/npub
   const details = [
-    { label: 'Nprofile', value: profileData.nprofile },
-    { label: 'Pubkey', value: pubkey },
     { label: 'Username', value: content.name },
     { label: 'NIP-05', value: content.nip05 },
     { label: 'LUD-16', value: content.lud16 },

--- a/static/style.css
+++ b/static/style.css
@@ -207,6 +207,17 @@ footer {
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.2);
 }
 
+/* Profile section styling */
+#profile-section {
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    max-width: 500px;
+    width: 80%;
+    margin: 20px auto;
+    background: #f9f9f9;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.2);
+}
+
 .gear-container {
     max-width: 300px;
     width: 100%;


### PR DESCRIPTION
## Summary
- remove relay.snort.social because it's timing out
- limit width of the profile section
- hide `nprofile` and `npub` values in the profile display

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688911c8ac4c8327a6ca954202209d70