### PR TITLE
Implement admin menu toggle via nip05 validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Fuzzed Records is a modern music platform that integrates decentralized authenti
 
 - **Music Library**: Browse and play songs hosted on Wavlake. The library includes detailed artist and album information.
 - **User Profiles**: Authenticate using Nostr Wallet to view and manage your profile, leveraging Nostr NIP-07 for login.
-- **Admin Panel**: Create and publish events (restricted to verified admins).
+ - **Admin Panel**: Create and publish events (visible when your NIP-05 address ends with `fuzzedrecords.com`).
 - **Decentralized Authentication**: Uses Nostr Wallet for secure, decentralized user authentication.
 - **Responsive Design**: Optimized for both desktop and mobile devices.
 - **QR Code Ticketing**: Generate QR code tickets for live music events, sent via Nostr DM to users.
@@ -296,7 +296,8 @@ If dependencies are missing, tests will fail with import errors similar to the o
    - The backend fetches and validates their profile data.
 
 3. **Admin Actions**:
-   - Verified admins can access the Admin section and create events.
+   - Users whose NIP-05 identifier ends with `fuzzedrecords.com` are treated as admins.
+   - The Admin menu becomes visible after login and allows creating events.
    - Events are published to Nostr relays.
 
 4. **Music Library**:

--- a/static/scripts/auth.js
+++ b/static/scripts/auth.js
@@ -110,8 +110,13 @@ export async function authenticateWithNostr() {
     }
     userProfile = profileData;
     renderProfileWhenReady(profileData);
-    await validateProfile(pubkey);
-    if (window.nostr.getRelays) {
+  const isAdmin = await validateProfile(pubkey);
+  localStorage.setItem('isAdmin', isAdmin ? 'true' : 'false');
+  const adminBtn = document.getElementById('menu-admin');
+  if (adminBtn) {
+    adminBtn.style.display = isAdmin ? 'inline-block' : 'none';
+  }
+  if (window.nostr.getRelays) {
       try {
         const info = await window.nostr.getRelays();
         const relays = Object.keys(info || {});
@@ -154,5 +159,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const sections = ['library', 'profile', 'events', 'admin', 'gear'];
   if (sections.includes(hash)) {
     showSection(hash);
+  }
+
+  const adminBtn = document.getElementById('menu-admin');
+  if (adminBtn && localStorage.getItem('isAdmin') === 'true') {
+    adminBtn.style.display = 'inline-block';
   }
 });

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import asyncio
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import nostr_utils
+import app
+
+class DummyMgr:
+    def __init__(self):
+        self.published = False
+    def add_relay(self, url):
+        pass
+    def publish_event(self, ev):
+        self.published = True
+    def close_connections(self):
+        pass
+
+async def _false(*args, **kwargs):
+    return False
+
+async def _true(*args, **kwargs):
+    return True
+
+
+def _basic_event_data():
+    return {
+        "pubkey": "00" * 32,
+        "sig": "sig",
+        "kind": 1,
+        "created_at": 0,
+        "tags": [],
+        "content": "x",
+    }
+
+
+def test_create_event_requires_valid_admin(monkeypatch):
+    mgr = DummyMgr()
+    monkeypatch.setattr(nostr_utils, "initialize_client", lambda: mgr)
+    monkeypatch.setattr(nostr_utils.Event, "verify", lambda self: True)
+    class DummyEK(int):
+        SET_METADATA = 0
+        TEXT_NOTE = 1
+        ENCRYPTED_DM = 4
+        CUSTOM_52 = 52
+    monkeypatch.setattr(nostr_utils, "EventKind", DummyEK)
+
+    # invalid admin -> 403
+    monkeypatch.setattr(nostr_utils, "fetch_and_validate_profile", _false)
+    with app.app.test_client() as client:
+        resp = client.post("/create_event", json=_basic_event_data())
+        assert resp.status_code == 403
+        assert not mgr.published
+
+    # valid admin -> 200
+    monkeypatch.setattr(nostr_utils, "fetch_and_validate_profile", _true)
+    with app.app.test_client() as client:
+        resp = client.post("/create_event", json=_basic_event_data())
+        assert resp.status_code == 200
+        assert mgr.published
+


### PR DESCRIPTION
## Summary
- show Admin menu only for nip05 addresses on fuzzedrecords.com
- persist admin flag in localStorage and restore on load
- clarify admin workflow in README
- add regression test for `/create_event` domain check

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688969d7ebfc8327bb125c4d838482f4