### PR TITLE
Update event kind for calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ If dependencies are missing, tests will fail with import errors similar to the o
 ### 5. Fetch Fuzzed Events
 - **Endpoint**: `/fuzzed_events`
 - **Method**: `GET`
-- **Description**: Retrieves Kind=52 events from verified accounts.
+- **Description**: Retrieves Kind=31922 events from verified accounts.
 - **Response**:
   ```json
   {"events":[{"id":"...","pubkey":"...",

--- a/nostr_client.py
+++ b/nostr_client.py
@@ -56,7 +56,7 @@ class EventKind:
     SET_METADATA = 0
     TEXT_NOTE = 1
     ENCRYPTED_DM = 4
-    CUSTOM_52 = 52
+    CALENDAR_EVENT = 31922
 
 @dataclass
 class Event:

--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -166,7 +166,7 @@ async def _create_event():
 @app.route('/fuzzed_events', methods=['GET'])
 async def _get_fuzzed_events():
     mgr = initialize_client()
-    filt = FiltersList([Filters(kinds=[52])])
+    filt = FiltersList([Filters(kinds=[EventKind.CALENDAR_EVENT])])
     await mgr.add_subscription_on_all_relays('fuzzed', filt)
     await asyncio.sleep(1)
     results = []

--- a/static/scripts/events.js
+++ b/static/scripts/events.js
@@ -54,7 +54,7 @@ export async function createEvent(e) {
   try {
     if (!window.nostr) throw new Error('Nostr wallet not available');
     const template = {
-      kind: 52,
+      kind: 31922,
       created_at: Math.floor(Date.now()/1000),
       tags: [
         ['title', eventData.title],

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -43,7 +43,7 @@ def test_create_event_requires_valid_admin(monkeypatch):
         SET_METADATA = 0
         TEXT_NOTE = 1
         ENCRYPTED_DM = 4
-        CUSTOM_52 = 52
+        CALENDAR_EVENT = 31922
     monkeypatch.setattr(nostr_utils, "EventKind", DummyEK)
 
     # invalid admin -> 403


### PR DESCRIPTION
## Summary
- replace `CUSTOM_52` with `CALENDAR_EVENT` kind (`31922`)
- use the new constant for filtering calendar events
- emit calendar events from the frontend using kind `31922`
- adjust tests for updated constant
- document the calendar event kind in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889732c643083279b6fa5f374eb5927