### PR TITLE
Add NIP-52 event form fields

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -94,16 +94,28 @@
                     <input type="text" id="event-title" name="event-title" required>
                 </div>
                 <div class="form-group">
-                    <label for="event-venue">Venue:</label>
-                    <input type="text" id="event-venue" name="event-venue" required>
+                    <label for="event-summary">Summary:</label>
+                    <input type="text" id="event-summary" name="event-summary" required>
                 </div>
                 <div class="form-group">
-                    <label for="event-date">Date:</label>
-                    <input type="datetime-local" id="event-date" name="event-date" required>
+                    <label for="event-location">Location:</label>
+                    <input type="text" id="event-location" name="event-location" required>
                 </div>
                 <div class="form-group">
-                    <label for="event-fee">Fee:</label>
-                    <input type="number" id="event-fee" name="event-fee" required>
+                    <label for="event-start">Start Time:</label>
+                    <input type="datetime-local" id="event-start" name="event-start" required>
+                </div>
+                <div class="form-group">
+                    <label for="event-end">End Time:</label>
+                    <input type="datetime-local" id="event-end" name="event-end" required>
+                </div>
+                <div class="form-group">
+                    <label for="event-price">Price:</label>
+                    <input type="number" id="event-price" name="event-price">
+                </div>
+                <div class="form-group">
+                    <label for="event-category">Category:</label>
+                    <input type="text" id="event-category" name="event-category">
                 </div>
                 <div class="form-group">
                     <label for="event-description">Description:</label>


### PR DESCRIPTION
## Summary
- expand admin event form to gather more details
- build NIP-52 tags and handle optional values
- read NIP-52 tags when displaying events
- keep ticket generation logic using the `title` tag

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897509f25c8327aa6d0949ecf50b4a