### PR TITLE
Send signed event id when creating events

### DIFF
--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -156,12 +156,13 @@ async def _create_event():
                kind=EventKind(data.get('kind',1)), tags=data.get('tags',[]),
                created_at=data.get('created_at', int(time.time())))
     ev.sig = data.get('sig')
+    ev.id = data.get('id')
     if not ev.verify():
         return error_response("Invalid signature", 403)
     mgr = initialize_client()
     mgr.publish_event(ev)
     mgr.close_connections()
-    return jsonify({"message":"Event successfully broadcasted"})
+    return jsonify({"message":"Event successfully broadcasted", "id": ev.id})
 
 @app.route('/fuzzed_events', methods=['GET'])
 async def _get_fuzzed_events():

--- a/static/scripts/events.js
+++ b/static/scripts/events.js
@@ -88,7 +88,7 @@ export async function createEvent(e) {
     const resp = await fetch('/create_event', {
       method: 'POST',
       headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({...template, sig: signed.sig})
+      body: JSON.stringify(signed)
     });
     if (!resp.ok) throw new Error((await resp.json()).error || 'Unknown');
     alert('Event created successfully!');

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -28,6 +28,7 @@ def _basic_event_data():
     return {
         "pubkey": "00" * 32,
         "sig": "sig",
+        "id": "11" * 32,
         "kind": 1,
         "created_at": 0,
         "tags": [],
@@ -56,7 +57,10 @@ def test_create_event_requires_valid_admin(monkeypatch):
     # valid admin -> 200
     monkeypatch.setattr(nostr_utils, "fetch_and_validate_profile", _true)
     with app.app.test_client() as client:
-        resp = client.post("/create_event", json=_basic_event_data())
+        data = _basic_event_data()
+        resp = client.post("/create_event", json=data)
         assert resp.status_code == 200
         assert mgr.published
+        resp_data = resp.get_json()
+        assert resp_data["id"] == data["id"]
 


### PR DESCRIPTION
## Summary
- send whole Nostr `signEvent` result from the browser
- keep event `id` when saving via `_create_event`
- expect `id` field in the admin access test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889768f833c8327917d928895746100