### PR TITLE
Document NIP‑52 calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,15 @@ If dependencies are missing, tests will fail with import errors similar to the o
 ### 3. Create Event (Admin Only)
 - **Endpoint**: `/create_event`
 - **Method**: `POST`
-- **Description**: Publishes a signed Kind=1 (text note) or custom event to relays.
+- **Description**: Publishes a signed Kind=1 (text note) or calendar event (NIP-52) to relays.
 - **Request Body**:
   ```json
   {"pubkey":"...","sig":"...","kind":1,"created_at":timestamp,
    "tags":[["title","event_title"],...],"content":"event_description"}
   ```
+- **NIP-52 Tags**: For `kind` `31922`, include tags like `['d', 'id']`, `['title','name']`,
+  `['summary','summary']`, `['location','venue']`, `['starts','unix_ts']`,
+  `['ends','unix_ts']` and optionally `['price','amount']`, `['category','type']`.
 - **Response**:
   ```json
   {"message":"Event successfully broadcasted"}
@@ -240,10 +243,11 @@ If dependencies are missing, tests will fail with import errors similar to the o
 - **Endpoint**: `/fuzzed_events`
 - **Method**: `GET`
 - **Description**: Retrieves Kind=31922 events from verified accounts.
+- **NIP-52 Tags**: Returned events contain tags defined above (e.g. `['title']`, `['location']`, `['starts']`, `['ends']`).
 - **Response**:
   ```json
   {"events":[{"id":"...","pubkey":"...",
-               "content":"...","tags":[],"created_at":...},...]} 
+               "content":"...","tags":[],"created_at":...},...]}
   ```
 
 ### 6. Send Encrypted DM (NIP-04)

--- a/nostr_client.py
+++ b/nostr_client.py
@@ -56,7 +56,7 @@ class EventKind:
     SET_METADATA = 0
     TEXT_NOTE = 1
     ENCRYPTED_DM = 4
-    CALENDAR_EVENT = 31922
+    CALENDAR_EVENT = 31922  # NIP-52 calendar events
 
 @dataclass
 class Event:

--- a/static/scripts/events.js
+++ b/static/scripts/events.js
@@ -78,6 +78,7 @@ export async function createEvent(e) {
     if (eventData.price) tags.push(['price', String(eventData.price)]);
     if (eventData.category) tags.push(['category', eventData.category]);
     const template = {
+      // NIP-52 calendar event kind
       kind: 31922,
       created_at: Math.floor(Date.now()/1000),
       tags,

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -44,7 +44,7 @@ def test_create_event_requires_valid_admin(monkeypatch):
         SET_METADATA = 0
         TEXT_NOTE = 1
         ENCRYPTED_DM = 4
-        CALENDAR_EVENT = 31922
+        CALENDAR_EVENT = 31922  # NIP-52 calendar events
     monkeypatch.setattr(nostr_utils, "EventKind", DummyEK)
 
     # invalid admin -> 403


### PR DESCRIPTION
## Summary
- document NIP‑52 calendar event tags for `/create_event` and `/fuzzed_events`
- clarify calendar event kind in code comments

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688978c4f7a883279f9167ab68f800d1