### PR TITLE
Restrict admin page visibility

### DIFF
--- a/static/scripts/auth.js
+++ b/static/scripts/auth.js
@@ -1,6 +1,6 @@
 // auth.js
 // Handles navigation and Nostr authentication (NIP-07) logic
-import { showSection } from './utils.js';
+import { showSection, isAdmin } from './utils.js';
 
 // Global profile state
 let userProfile = null;
@@ -110,11 +110,11 @@ export async function authenticateWithNostr() {
     }
     userProfile = profileData;
     renderProfileWhenReady(profileData);
-  const isAdmin = await validateProfile(pubkey);
-  localStorage.setItem('isAdmin', isAdmin ? 'true' : 'false');
+  const adminStatus = await validateProfile(pubkey);
+  localStorage.setItem('isAdmin', adminStatus ? 'true' : 'false');
   const adminBtn = document.getElementById('menu-admin');
   if (adminBtn) {
-    adminBtn.style.display = isAdmin ? 'inline-block' : 'none';
+    adminBtn.style.display = adminStatus ? 'inline-block' : 'none';
   }
   if (window.nostr.getRelays) {
       try {
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const adminBtn = document.getElementById('menu-admin');
-  if (adminBtn && localStorage.getItem('isAdmin') === 'true') {
-    adminBtn.style.display = 'inline-block';
+  if (adminBtn) {
+    adminBtn.style.display = isAdmin() ? 'inline-block' : 'none';
   }
 });

--- a/static/scripts/events.js
+++ b/static/scripts/events.js
@@ -1,6 +1,6 @@
 // events.js
 // Handles events section: fetching, rendering, and admin event creation
-import { showSection, getTagValue } from './utils.js';
+import { showSection, getTagValue, isAdmin } from './utils.js';
 
 // Fetch and display fuzzed events
 export async function fetchFuzzedEvents() {
@@ -111,6 +111,10 @@ document.addEventListener('DOMContentLoaded', () => {
       alert('Please sign in with Nostr to view events.');
     }
   });
-  btnAdmin?.addEventListener('click', () => showSection('admin'));
+  btnAdmin?.addEventListener('click', () => {
+    if (isAdmin()) {
+      showSection('admin');
+    }
+  });
   document.getElementById('event-form')?.addEventListener('submit', createEvent);
 });

--- a/static/scripts/utils.js
+++ b/static/scripts/utils.js
@@ -1,6 +1,16 @@
 // utils.js - shared helper functions
 // Switch between content sections
+export function isAdmin() {
+  return (
+    localStorage.getItem('isAdmin') === 'true' &&
+    Boolean(localStorage.getItem('pubkey'))
+  );
+}
+
 export function showSection(section) {
+  if (section === 'admin' && !isAdmin()) {
+    return; // Block non-admins from showing admin section
+  }
   const sections = ['library', 'profile', 'events', 'admin', 'gear'];
   sections.forEach(sec => {
     const el = document.getElementById(`${sec}-section`);


### PR DESCRIPTION
## Summary
- add `isAdmin()` helper and only allow admin section when user is validated
- hide admin button unless `pubkey` and `isAdmin` flag are present
- block admin section navigation for non-admin users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897a109ba883278a210b525114aaa1