### PR TITLE
Fix admin button visibility

### DIFF
--- a/static/scripts/auth.js
+++ b/static/scripts/auth.js
@@ -92,7 +92,7 @@ export async function authenticateWithNostr() {
   try {
     const pubkey = await window.nostr.getPublicKey();
     console.log('Retrieved pubkey:', pubkey);
-    localStorage.setItem('pubkey', pubkey);
+    sessionStorage.setItem('pubkey', pubkey);
     console.log('Fetching profile for', pubkey);
     const response = await fetch('/fetch-profile', {
       method: 'POST',
@@ -111,7 +111,7 @@ export async function authenticateWithNostr() {
     userProfile = profileData;
     renderProfileWhenReady(profileData);
   const adminStatus = await validateProfile(pubkey);
-  localStorage.setItem('isAdmin', adminStatus ? 'true' : 'false');
+  sessionStorage.setItem('isAdmin', adminStatus ? 'true' : 'false');
   const adminBtn = document.getElementById('menu-admin');
   if (adminBtn) {
     adminBtn.style.display = adminStatus ? 'inline-block' : 'none';
@@ -138,6 +138,9 @@ export async function authenticateWithNostr() {
 
 // Initialization: menu buttons
 document.addEventListener('DOMContentLoaded', () => {
+  // Remove any persisted admin state from older versions
+  localStorage.removeItem('pubkey');
+  localStorage.removeItem('isAdmin');
   document.getElementById('menu-library')
     .addEventListener('click', () => showSection('library'));
   document.getElementById('menu-gear')

--- a/static/scripts/events.js
+++ b/static/scripts/events.js
@@ -11,7 +11,7 @@ export async function fetchFuzzedEvents() {
     const response = await fetch('/fuzzed_events');
     const data = await response.json();
     if (data.events && data.events.length > 0) {
-      if (registerBtn && localStorage.getItem('pubkey')) {
+      if (registerBtn && sessionStorage.getItem('pubkey')) {
         registerBtn.style.display = 'inline-block';
       }
       data.events.forEach(ev => {
@@ -63,7 +63,7 @@ export async function createEvent(e) {
     price: data.get('event-price'),
     category: data.get('event-category'),
     description: data.get('event-description'),
-    pubkey: localStorage.getItem('pubkey')
+    pubkey: sessionStorage.getItem('pubkey')
   };
   try {
     if (!window.nostr) throw new Error('Nostr wallet not available');
@@ -105,7 +105,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnEvents = document.getElementById('menu-events');
   const btnAdmin = document.getElementById('menu-admin');
   btnEvents?.addEventListener('click', () => {
-    if (localStorage.getItem('pubkey')) {
+    if (sessionStorage.getItem('pubkey')) {
       fetchFuzzedEvents();
       showSection('events');
     } else {

--- a/static/scripts/ticket.js
+++ b/static/scripts/ticket.js
@@ -10,7 +10,7 @@ export async function generateTicketWithQRCode(eventData) {
   const ticketData = {
     ticket_id: ticketId,
     event_id: eventId,
-    pubkey: localStorage.getItem('pubkey'),
+    pubkey: sessionStorage.getItem('pubkey'),
     event_name: eventName
   };
   const qrContainer = document.getElementById('qr-code');
@@ -38,7 +38,7 @@ async function sendTicketViaNostrDM(ticketData) {
       created_at: Math.floor(Date.now() / 1000),
       tags: [['p', ticketData.pubkey]],
       content: encrypted,
-      pubkey: localStorage.getItem('pubkey')
+      pubkey: sessionStorage.getItem('pubkey')
     };
     const signed = await window.nostr.signEvent(dmEvent);
     const resp = await fetch('/send_ticket', {

--- a/static/scripts/utils.js
+++ b/static/scripts/utils.js
@@ -2,8 +2,8 @@
 // Switch between content sections
 export function isAdmin() {
   return (
-    localStorage.getItem('isAdmin') === 'true' &&
-    Boolean(localStorage.getItem('pubkey'))
+    sessionStorage.getItem('isAdmin') === 'true' &&
+    Boolean(sessionStorage.getItem('pubkey'))
   );
 }
 


### PR DESCRIPTION
## Summary
- use `sessionStorage` instead of `localStorage` for authentication data
- clear old admin data on page load

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897d2b418c832796ae3a3a7bbad64c