### PR TITLE
Support NIP-17 ephemeral DMs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ gunicorn>=20.1.0
 azure-data-tables>=12.6.0
 pytest>=7.4
 websockets>=15.0
+cryptography>=42.0

--- a/tests/test_send_ticket.py
+++ b/tests/test_send_ticket.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import ticket_utils
 import app
+import nostr_client
 
 
 class DummyEvent:
@@ -14,34 +15,37 @@ class DummyEvent:
         self.priv = priv
 
 
-class DummyEncryptedDM:
-    def encrypt(self, private_key_hex, cleartext_content, recipient_pubkey):
-        self.args = (private_key_hex, cleartext_content, recipient_pubkey)
-    def to_event(self):
-        return DummyEvent()
-
-
 class DummyRelayManager:
     def __init__(self):
         self.publish_count = 0
+        self.last_event = None
     def add_relay(self, url):
         self.last_relay = url
     def publish_event(self, ev):
         self.publish_count += 1
+        self.last_event = ev
     def close_connections(self):
         self.closed = True
 
 
 def test_send_ticket_as_dm(monkeypatch):
     mgr = DummyRelayManager()
-    monkeypatch.setattr(ticket_utils, "EncryptedDirectMessage", DummyEncryptedDM)
     monkeypatch.setattr(ticket_utils, "initialize_client", lambda: mgr)
     monkeypatch.setattr(app, "initialize_client", lambda: mgr)
     monkeypatch.setattr(app, "RelayManager", DummyRelayManager)
 
+    called = {}
+    def fake_encrypt(priv, pub, text):
+        called["args"] = (priv, pub, text)
+        return "cipher"
+
+    monkeypatch.setattr(nostr_client, "nip17_encrypt", fake_encrypt)
+
     ev_id = ticket_utils.send_ticket_as_dm(
-        "Concert", "recip_pubkey", "sender_privkey", timestamp=123
+        "Concert", "recip_pubkey", "11" * 32, timestamp=123
     )
 
-    assert ev_id == "dummy_event_id"
     assert mgr.publish_count == 1
+    assert mgr.last_event.kind == nostr_client.EventKind.EPHEMERAL_DM
+    assert called["args"][0] == "11" * 32
+    assert called["args"][1] == "recip_pubkey"

--- a/ticket_utils.py
+++ b/ticket_utils.py
@@ -11,7 +11,7 @@ initialize_client = None
 error_response = None
 logger = None
 limiter = None
-from nostr_client import EncryptedDirectMessage
+from nostr_client import EncryptedDirectMessage, EventKind
 
 
 def _load_app_dependencies():
@@ -39,7 +39,7 @@ def send_ticket_as_dm(event_name: str, recipient_pubkey_hex: str,
     # Generate payload (QR image is not needed for DM)
     _load_app_dependencies()
     payload_str, _ = generate_ticket(event_name, recipient_pubkey_hex, timestamp)
-    dm = EncryptedDirectMessage()
+    dm = EncryptedDirectMessage(kind=EventKind.EPHEMERAL_DM)
     dm.encrypt(private_key_hex=sender_privkey_hex,
                cleartext_content=payload_str,
                recipient_pubkey=recipient_pubkey_hex)


### PR DESCRIPTION
## Summary
- add `EPHEMERAL_DM` event kind
- implement `nip17_encrypt` helper using AES-GCM
- update `EncryptedDirectMessage` to optionally create NIP-17 messages
- send tickets using ephemeral DMs
- add `cryptography` package
- adjust tests for new encryption helper

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889871be2f083278a18dd41c3cef97d