### PR TITLE
Add debug output for event publishing

### DIFF
--- a/nostr_client.py
+++ b/nostr_client.py
@@ -232,12 +232,15 @@ class RelayManager:
 
     def publish_event(self, event: Event):
         msg = json.dumps(["EVENT", event.to_dict()])
-        for r in self.relays.values():
+        for url, r in self.relays.items():
             if r.ws:
+                logger.debug("Sending message to %s: %s", url, msg)
                 try:
                     asyncio.create_task(r.ws.send(msg))
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.error("Failed to send to %s: %s", url, exc)
+            else:
+                logger.debug("Relay %s not connected; skipping send", url)
 
     def close_connections(self):
         for r in self.relays.values():

--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -168,6 +168,7 @@ async def _create_event():
     ev.id = data.get('id')
     if not ev.verify():
         return error_response("Invalid signature", 403)
+    logger.debug("Created event for publish: %s", ev.to_dict())
     mgr = initialize_client()
     mgr.publish_event(ev)
     mgr.close_connections()


### PR DESCRIPTION
## Summary
- log event dictionary when creating events
- log WebSocket relay URL and message when sending events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889886372588327ad79dcd19c5adce8