### PR TITLE
Fix DM pubkey and update tests

### DIFF
--- a/nostr_client.py
+++ b/nostr_client.py
@@ -300,6 +300,12 @@ class EncryptedDirectMessage:
             self.content = cleartext_content
 
     def to_event(self) -> Event:
+        """Return an ``Event`` representing this message.
+
+        The ``pubkey`` field in the resulting event must reference the
+        **sender's** public key. Older versions incorrectly used the
+        recipient's pubkey here which resulted in invalid signatures.
+        """
         return Event(
             public_key=self.sender_pubkey,
             content=self.content,

--- a/tests/test_send_ticket.py
+++ b/tests/test_send_ticket.py
@@ -49,3 +49,7 @@ def test_send_ticket_as_dm(monkeypatch):
     assert mgr.last_event.kind == nostr_client.EventKind.EPHEMERAL_DM
     assert called["args"][0] == "11" * 32
     assert called["args"][1] == "recip_pubkey"
+    # ensure the event is published from the sender and tagged with the recipient
+    expected_sender = nostr_client.derive_public_key_hex("11" * 32)
+    assert mgr.last_event.public_key == expected_sender
+    assert mgr.last_event.tags == [["p", "recip_pubkey"]]


### PR DESCRIPTION
## Summary
- clarify that EncryptedDirectMessage events should use sender pubkey
- verify DM events publish from the sender in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68898f27108c8327b8d964987d134105