### PR TITLE
Prepare relays for fuzzed events

### DIFF
--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -179,6 +179,11 @@ async def _create_event():
 @app.route('/fuzzed_events', methods=['GET'])
 async def _get_fuzzed_events():
     mgr = initialize_client()
+    await mgr.prepare_relays()
+    statuses = getattr(mgr, "connection_statuses", {})
+    if statuses and not any(statuses.values()):
+        logger.error("Unable to connect to any Nostr relays: %s", statuses)
+        return error_response("Unable to connect to Nostr relays", 503)
     filt = FiltersList([Filters(kinds=[EventKind.CALENDAR_EVENT])])
     await mgr.add_subscription_on_all_relays('fuzzed', filt)
     await asyncio.sleep(1)

--- a/tests/test_fuzzed_events.py
+++ b/tests/test_fuzzed_events.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import nostr_utils
+from app import app
+from nostr_client import MessagePool
+
+class DummyMgr:
+    def __init__(self, status=True):
+        self.prepared = False
+        self.subscribed = False
+        self.closed = False
+        self._status = status
+        self.message_pool = MessagePool()
+    async def prepare_relays(self):
+        self.prepared = True
+    async def add_subscription_on_all_relays(self, sub_id, filt):
+        self.subscribed = True
+    def close_connections(self):
+        self.closed = True
+    @property
+    def connection_statuses(self):
+        return {"r1": self._status}
+
+
+def test_fuzzed_events_success(monkeypatch):
+    mgr = DummyMgr(True)
+    monkeypatch.setattr(nostr_utils, "initialize_client", lambda: mgr)
+    monkeypatch.setattr(nostr_utils, "fetch_and_validate_profile", lambda *a, **k: True)
+    with app.test_client() as client:
+        resp = client.get("/fuzzed_events")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"events": []}
+        assert mgr.prepared
+        assert mgr.subscribed
+        assert mgr.closed
+
+
+def test_fuzzed_events_returns_503(monkeypatch):
+    mgr = DummyMgr(False)
+    monkeypatch.setattr(nostr_utils, "initialize_client", lambda: mgr)
+    with app.test_client() as client:
+        resp = client.get("/fuzzed_events")
+        assert resp.status_code == 503
+        assert "Unable to connect" in resp.get_json()["error"]


### PR DESCRIPTION
## Summary
- ensure `mgr.prepare_relays()` is called before fetching fuzzed events
- return 503 if none of the relays connect
- test `/fuzzed_events` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889997785688327887e0ee63d04cfc6