### PR TITLE
Make connection closing async

### DIFF
--- a/app.py
+++ b/app.py
@@ -170,7 +170,7 @@ def fetch_profile_by_pubkey(pubkey, relays):
                         continue
                 await asyncio.sleep(0.1)
         finally:
-            manager.close_connections()
+            await manager.close_connections()
         return profile
 
     return asyncio.run(_run())

--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -99,7 +99,7 @@ async def fetch_profile():
                 # Ignore EOSE and continue waiting
                 continue
         await asyncio.sleep(0.05)
-    mgr.close_connections()
+    await mgr.close_connections()
     if profile_data:
         if nprof and "nprofile" not in profile_data:
             profile_data["nprofile"] = nprof
@@ -136,7 +136,7 @@ async def fetch_and_validate_profile(pubkey, required_domain):
         except Exception:
             continue
         break
-    mgr.close_connections()
+    await mgr.close_connections()
 
     if not profile_data:
         return False
@@ -189,7 +189,7 @@ async def _create_event():
     await mgr.prepare_relays()
     await mgr.publish_event(ev)
     await asyncio.sleep(0.5)
-    mgr.close_connections()
+    await mgr.close_connections()
     return jsonify({"message":"Event successfully broadcasted", "id": ev.id})
 
 @app.route('/fuzzed_events', methods=['GET'])
@@ -215,7 +215,7 @@ async def _get_fuzzed_events():
                 'content':ev.content, 'tags':ev.tags,
                 'created_at':ev.created_at
             })
-    mgr.close_connections()
+    await mgr.close_connections()
     return jsonify({'events':results})
 
 @app.route('/send_dm', methods=['POST'])
@@ -234,5 +234,5 @@ async def _send_dm():
     await mgr.prepare_relays()
     await mgr.publish_event(ev)
     await asyncio.sleep(0.5)
-    mgr.close_connections()
+    await mgr.close_connections()
     return jsonify({"message":"DM sent successfully"})

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -17,7 +17,7 @@ class DummyMgr:
         self.prepared = True
     async def publish_event(self, ev):
         self.published = True
-    def close_connections(self):
+    async def close_connections(self):
         pass
 
 async def _false(*args, **kwargs):

--- a/tests/test_fuzzed_events.py
+++ b/tests/test_fuzzed_events.py
@@ -18,7 +18,7 @@ class DummyMgr:
         self.prepared = True
     async def add_subscription_on_all_relays(self, sub_id, filt):
         self.subscribed = True
-    def close_connections(self):
+    async def close_connections(self):
         self.closed = True
     @property
     def connection_statuses(self):

--- a/tests/test_send_ticket.py
+++ b/tests/test_send_ticket.py
@@ -24,7 +24,7 @@ class DummyRelayManager:
     async def publish_event(self, ev):
         self.publish_count += 1
         self.last_event = ev
-    def close_connections(self):
+    async def close_connections(self):
         self.closed = True
 
 

--- a/ticket_utils.py
+++ b/ticket_utils.py
@@ -47,7 +47,7 @@ def send_ticket_as_dm(event_name: str, recipient_pubkey_hex: str,
     ev.sign(sender_privkey_hex)
     mgr = initialize_client()
     asyncio.run(mgr.publish_event(ev))
-    mgr.close_connections()
+    asyncio.run(mgr.close_connections())
     return ev.id
 
 def register_ticket_routes(app):


### PR DESCRIPTION
## Summary
- make RelayManager.close_connections async
- handle _recv_loop tasks during shutdown
- await connection closing in app and utils
- update ticket utils and tests for async closing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab87edde88327ac3864b2ccb169bc