### PR TITLE
Add cached pubkey whitelist for fuzzed events

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Set the following environment variables to configure the application:
 - PROFILE_FETCH_TIMEOUT: Seconds to wait for a user profile event when handling `/fetch-profile` or `/validate-profile` (default: 5)
 - RELAY_CONNECT_TIMEOUT: Seconds allowed to establish each WebSocket connection to a relay (default: 2)
 - DISABLE_TLS_VERIFY: Set to 1 to disable TLS certificate verification when connecting to relays (default: 0)
+- VALID_PUBKEYS: Comma-separated list of pubkeys allowed for fuzzed events. If unset, the app loads from the local file specified by IDENTITIES_CACHE (default: azure_identities.json)
 - TENANT_ID: Azure AD Tenant ID for discovery JSON endpoint (/.well-known/nostr.json)
 - CLIENT_ID: Azure AD Application (client) ID
 - CLIENT_SECRET: Azure AD Application client secret

--- a/app.py
+++ b/app.py
@@ -78,6 +78,31 @@ PROFILE_FETCH_TIMEOUT = float(os.getenv("PROFILE_FETCH_TIMEOUT", "5"))
 RELAY_CONNECT_TIMEOUT = float(os.getenv("RELAY_CONNECT_TIMEOUT", "2"))
 DISABLE_TLS_VERIFY = os.getenv("DISABLE_TLS_VERIFY", "0").lower() in {"1", "true", "yes"}
 
+# Comma-separated list of pubkeys allowed to publish calendar events. If unset,
+# a local cache file specified by IDENTITIES_CACHE (default 'azure_identities.json')
+# is read when present.
+def load_valid_pubkeys():
+    env_val = os.getenv("VALID_PUBKEYS", "").strip()
+    if env_val:
+        return [p.strip() for p in env_val.split(",") if p.strip()]
+    cache_file = os.getenv("IDENTITIES_CACHE", "azure_identities.json")
+    if os.path.exists(cache_file):
+        try:
+            import json
+            with open(cache_file) as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                return [p for p in data if isinstance(p, str)]
+            if isinstance(data, dict):
+                # Expect structure from azure_resources {"names": {name: pubkey}}
+                if "names" in data and isinstance(data["names"], dict):
+                    return [pk for pk in data["names"].values() if isinstance(pk, str)]
+        except Exception as e:
+            logger.warning("Failed to load identities cache %s: %s", cache_file, e)
+    return []
+
+VALID_PUBKEYS = load_valid_pubkeys()
+
 # Logging setup
 logging.basicConfig(level=os.getenv('LOG_LEVEL', 'DEBUG'))
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- allow configuring VALID_PUBKEYS via env or azure identity cache
- expose VALID_PUBKEYS to nostr_utils
- skip profile validation for whitelisted pubkeys when returning fuzzed events
- document new env var in README
- test fuzzed events whitelist logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac65e5c1c83278c5855a0c3addd72