### PR TITLE
Fix README relay defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Fuzzed Records is a modern music platform that integrates decentralized authenti
 
 Set the following environment variables to configure the application:
 
-- RELAY_URLS: Comma-separated list of Nostr relay URLs (default: wss://relay.damus.io,wss://relay.primal.net,wss://relay.mostr.pub,wss://nos.lol). If unset and no relay list files exist, this default list populates `ACTIVE_RELAYS`.
+- RELAY_URLS: Comma-separated list of Nostr relay URLs (default: wss://relay.damus.io,wss://relay.primal.net,wss://relay.nostr.pub,wss://nos.lol). If unset and no relay list files exist, this default list populates `ACTIVE_RELAYS`.
 - CACHE_TIMEOUT: Seconds to cache fetched user profiles (default: 300)
 - REQUIRED_DOMAIN: Domain for NIP-05 profile verification (default: fuzzedrecords.com)
 - MAX_CONTENT_LENGTH: Max request payload size in bytes (default: 1048576)


### PR DESCRIPTION
## Summary
- update default `RELAY_URLS` in README to match `app.py`
- replace old relay.mostr.pub URL with relay.nostr.pub

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad27ea32883278c2b333871b3f6e0