### PR TITLE
Simplify event retrieval

### DIFF
--- a/nostr_client.py
+++ b/nostr_client.py
@@ -54,6 +54,14 @@ def nprofile_decode(value: str):
         i += 2 + l
     return "nprofile", {"pubkey": pubkey, "relays": relays}
 
+def npub_to_hex(value: str) -> str:
+    """Decode a bech32 ``npub`` string into a hex pubkey."""
+    hrp, data = bech32.bech32_decode(value)
+    if hrp != "npub" or data is None:
+        raise ValueError("Invalid npub")
+    decoded = bech32.convertbits(data, 5, 8, False)
+    return bytes(decoded).hex()
+
 # --- Event and Filters ---
 
 class EventKind:

--- a/tests/test_fuzzed_events.py
+++ b/tests/test_fuzzed_events.py
@@ -1,5 +1,4 @@
-import os
-import sys
+import os, sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -9,108 +8,61 @@ from nostr_client import MessagePool, Event, EventKind
 
 class DummyMgr:
     def __init__(self, status=True):
+        self.added = []
         self.prepared = False
         self.subscribed = False
         self.closed = False
         self._status = status
         self.message_pool = MessagePool()
+
+    def add_relay(self, url):
+        self.added.append(url)
+
     async def prepare_relays(self):
         self.prepared = True
+
     async def add_subscription_on_all_relays(self, sub_id, filt):
         self.subscribed = True
+        self.sub_id = sub_id
+        self.filt = filt
+
     async def close_connections(self):
         self.closed = True
+
     @property
     def connection_statuses(self):
-        return {"r1": self._status}
+        return {self.added[0] if self.added else "r": self._status}
 
 
 def test_fuzzed_events_success(monkeypatch):
     mgr = DummyMgr(True)
-    monkeypatch.setattr(nostr_utils, "initialize_client", lambda: mgr)
-    monkeypatch.setattr(nostr_utils, "fetch_and_validate_profile", lambda *a, **k: True)
+    monkeypatch.setattr(nostr_utils, "RelayManager", lambda timeout=0: mgr)
     with app.test_client() as client:
         resp = client.get("/fuzzed_events")
         assert resp.status_code == 200
         assert resp.get_json() == {"events": []}
-        assert mgr.prepared
-        assert mgr.subscribed
-        assert mgr.closed
+    assert mgr.added == [nostr_utils.EVENTS_RELAY]
+    assert mgr.prepared
+    assert mgr.subscribed
+    assert mgr.closed
 
 
-def test_fuzzed_events_returns_503(monkeypatch):
-    mgr = DummyMgr(False)
-    monkeypatch.setattr(nostr_utils, "initialize_client", lambda: mgr)
-    with app.test_client() as client:
-        resp = client.get("/fuzzed_events")
-        assert resp.status_code == 503
-        assert "Unable to connect" in resp.get_json()["error"]
-
-
-def test_fuzzed_events_skips_validation_for_allowed(monkeypatch):
+def test_fuzzed_events_returns_events(monkeypatch):
     mgr = DummyMgr(True)
-    ev = Event(public_key="aa", content="x", kind=EventKind.CALENDAR_EVENT)
+    ev = Event(public_key=nostr_utils.EVENTS_PUBKEY_HEX, content="x", kind=EventKind.CALENDAR_EVENT)
     mgr.message_pool.add_event("fuzzed", ev)
-    monkeypatch.setattr(nostr_utils, "initialize_client", lambda: mgr)
-
-    called = False
-    async def fake_validate(*args, **kwargs):
-        nonlocal called
-        called = True
-        return False
-
-    monkeypatch.setattr(nostr_utils, "fetch_and_validate_profile", fake_validate)
-    monkeypatch.setattr(nostr_utils, "VALID_PUBKEYS", ["aa"])
-
+    monkeypatch.setattr(nostr_utils, "RelayManager", lambda timeout=0: mgr)
     with app.test_client() as client:
         resp = client.get("/fuzzed_events")
         assert resp.status_code == 200
         data = resp.get_json()
         assert len(data["events"]) == 1
-        assert data["events"][0]["pubkey"] == "aa"
-        assert not called
+        assert data["events"][0]["content"] == "x"
 
 
-def test_fuzzed_events_filters_invalid(monkeypatch):
-    mgr = DummyMgr(True)
-    ev = Event(public_key="bb", content="x", kind=EventKind.CALENDAR_EVENT)
-    mgr.message_pool.add_event("fuzzed", ev)
-    monkeypatch.setattr(nostr_utils, "initialize_client", lambda: mgr)
-
-    calls = []
-    async def fake_validate(pk, domain):
-        calls.append(pk)
-        return False
-
-    monkeypatch.setattr(nostr_utils, "fetch_and_validate_profile", fake_validate)
-    monkeypatch.setattr(nostr_utils, "VALID_PUBKEYS", [])
-
+def test_fuzzed_events_returns_503(monkeypatch):
+    mgr = DummyMgr(False)
+    monkeypatch.setattr(nostr_utils, "RelayManager", lambda timeout=0: mgr)
     with app.test_client() as client:
         resp = client.get("/fuzzed_events")
-        assert resp.status_code == 200
-        assert resp.get_json() == {"events": []}
-        assert calls == ["bb"]
-
-
-def test_fuzzed_events_multiple_events_same_pubkey(monkeypatch):
-    mgr = DummyMgr(True)
-    ev1 = Event(public_key="cc", content="e1", kind=EventKind.CALENDAR_EVENT)
-    ev2 = Event(public_key="cc", content="e2", kind=EventKind.CALENDAR_EVENT)
-    mgr.message_pool.add_event("fuzzed", ev1)
-    mgr.message_pool.add_event("fuzzed", ev2)
-    monkeypatch.setattr(nostr_utils, "initialize_client", lambda: mgr)
-
-    calls = []
-    async def fake_validate(pk, domain):
-        calls.append(pk)
-        return True
-
-    monkeypatch.setattr(nostr_utils, "fetch_and_validate_profile", fake_validate)
-    monkeypatch.setattr(nostr_utils, "VALID_PUBKEYS", [])
-
-    with app.test_client() as client:
-        resp = client.get("/fuzzed_events")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert [e["content"] for e in data["events"]] == ["e1", "e2"]
-        assert calls == ["cc"]
+        assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- add `npub_to_hex` helper for decoding npub strings
- fetch events from a single relay (nos.lol) using a fixed npub
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688adbb6bd108327ac666493058a6ab8