### PR TITLE
Prepare relays before sending ticket DM

### DIFF
--- a/tests/test_send_ticket.py
+++ b/tests/test_send_ticket.py
@@ -19,8 +19,11 @@ class DummyRelayManager:
     def __init__(self):
         self.publish_count = 0
         self.last_event = None
+        self.prepared = False
     def add_relay(self, url):
         self.last_relay = url
+    async def prepare_relays(self):
+        self.prepared = True
     async def publish_event(self, ev):
         self.publish_count += 1
         self.last_event = ev
@@ -46,6 +49,7 @@ def test_send_ticket_as_dm(monkeypatch):
     )
 
     assert mgr.publish_count == 1
+    assert mgr.prepared
     assert mgr.last_event.kind == nostr_client.EventKind.EPHEMERAL_DM
     assert called["args"][0] == "11" * 32
     assert called["args"][1] == "recip_pubkey"

--- a/ticket_utils.py
+++ b/ticket_utils.py
@@ -46,6 +46,7 @@ def send_ticket_as_dm(event_name: str, recipient_pubkey_hex: str,
     ev = dm.to_event()
     ev.sign(sender_privkey_hex)
     mgr = initialize_client()
+    asyncio.run(mgr.prepare_relays())
     asyncio.run(mgr.publish_event(ev))
     asyncio.run(mgr.close_connections())
     return ev.id


### PR DESCRIPTION
## Summary
- set up relay connections before publishing ticket DM events
- ensure dummy relay manager exposes `prepare_relays`
- check that `send_ticket_as_dm` prepares relays in unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae18563e883279bd53210670068bc