### PR TITLE
Load fuzzed events relays from file

### DIFF
--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -204,7 +204,16 @@ async def _create_event():
 @app.route('/fuzzed_events', methods=['GET'])
 async def _get_fuzzed_events():
     mgr = RelayManager(timeout=RELAY_CONNECT_TIMEOUT)
-    mgr.add_relay(EVENTS_RELAY)
+    relays = []
+    try:
+        with open("good-relays.txt") as f:
+            relays = [l.strip() for l in f if l.strip()]
+    except FileNotFoundError:
+        relays = [EVENTS_RELAY]
+    if not relays:
+        relays = [EVENTS_RELAY]
+    for url in relays:
+        mgr.add_relay(url)
     await mgr.prepare_relays()
     statuses = getattr(mgr, "connection_statuses", {})
     if statuses and not any(statuses.values()):

--- a/tests/test_fuzzed_events.py
+++ b/tests/test_fuzzed_events.py
@@ -34,7 +34,9 @@ class DummyMgr:
         return {self.added[0] if self.added else "r": self._status}
 
 
-def test_fuzzed_events_success(monkeypatch):
+def test_fuzzed_events_success(monkeypatch, tmp_path):
+    """Should use default relay when no good-relays file is present."""
+    monkeypatch.chdir(tmp_path)
     mgr = DummyMgr(True)
     monkeypatch.setattr(nostr_utils, "RelayManager", lambda timeout=0: mgr)
     with app.test_client() as client:
@@ -47,7 +49,8 @@ def test_fuzzed_events_success(monkeypatch):
     assert mgr.closed
 
 
-def test_fuzzed_events_returns_events(monkeypatch):
+def test_fuzzed_events_returns_events(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     mgr = DummyMgr(True)
     ev = Event(public_key=nostr_utils.EVENTS_PUBKEY_HEX, content="x", kind=EventKind.CALENDAR_EVENT)
     mgr.message_pool.add_event("fuzzed", ev)
@@ -60,9 +63,23 @@ def test_fuzzed_events_returns_events(monkeypatch):
         assert data["events"][0]["content"] == "x"
 
 
-def test_fuzzed_events_returns_503(monkeypatch):
+def test_fuzzed_events_returns_503(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     mgr = DummyMgr(False)
     monkeypatch.setattr(nostr_utils, "RelayManager", lambda timeout=0: mgr)
     with app.test_client() as client:
         resp = client.get("/fuzzed_events")
         assert resp.status_code == 503
+
+
+def test_fuzzed_events_uses_good_relays(monkeypatch, tmp_path):
+    """Relays should be loaded from good-relays.txt when available."""
+    monkeypatch.chdir(tmp_path)
+    good_file = tmp_path / "good-relays.txt"
+    good_file.write_text("wss://a.com\nwss://b.com\n")
+    mgr = DummyMgr(True)
+    monkeypatch.setattr(nostr_utils, "RelayManager", lambda timeout=0: mgr)
+    with app.test_client() as client:
+        resp = client.get("/fuzzed_events")
+        assert resp.status_code == 200
+    assert mgr.added == ["wss://a.com", "wss://b.com"]


### PR DESCRIPTION
## Summary
- load fuzzed events relays from `good-relays.txt` if present
- default to single `EVENTS_RELAY` when file missing
- adjust fuzzed events tests and add coverage for multiple relays

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae32b669883279444d029e7b81ce7