### PR TITLE
Update prerequisite wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Set the following environment variables to configure the application:
 ## Setup and Deployment
 
 ### Prerequisites
-- Python 3.x
+- Python 3.11 or newer *(older versions fail due to type-hint syntax)*
 - Nostr Wallet (for authentication)
 - Microsoft Azure account (for deployment)
 


### PR DESCRIPTION
## Summary
- update Python prerequisite in README to specify Python 3.11+
- mention that older Python versions fail due to type-hint syntax

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6f9b52e083279c48269b3f06afc8