### PR TITLE
Ensure Optional typing for relay_url

### DIFF
--- a/nostr_client.py
+++ b/nostr_client.py
@@ -118,7 +118,7 @@ class FiltersList:
 class _EventMsg:
     subscription_id: str
     event: Event
-    relay_url: str | None = None
+    relay_url: Optional[str] = None
 
 @dataclass
 class _EOSEMsg:
@@ -129,7 +129,7 @@ class MessagePool:
         self._events: asyncio.Queue[_EventMsg] = asyncio.Queue()
         self._eose: asyncio.Queue[_EOSEMsg] = asyncio.Queue()
 
-    def add_event(self, sub_id: str, event: Event, relay_url: str | None = None):
+    def add_event(self, sub_id: str, event: Event, relay_url: Optional[str] = None):
         self._events.put_nowait(_EventMsg(sub_id, event, relay_url))
 
     def add_eose(self, sub_id: str):


### PR DESCRIPTION
## Summary
- update `nostr_client.py` to use `Optional[str]` for `relay_url`
- keep `Optional` imported from `typing`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7702aa2c8327a1bd343c4c5f83ea