### PR TITLE
Fix fuzzedguitars redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fuzzed Records is a modern music platform that integrates decentralized authenti
 - **Rate Limiting**: Protects API endpoints using Flask-Limiter with optional Azure Table Storage backend.
 - **CORS Configuration**: Allowed origins can be customized via environment variable.
 - **Section Links**: Use URL hashes like `/#gear` to open a specific section directly.
-- **Fuzzed Guitars**: Boutique gear prototypes can be viewed in the Gear section (`/#gear`) or via the `fuzzedguitars` subdomain.
+- **Fuzzed Guitars**: Boutique gear prototypes can be viewed in the Gear section (`/#gear`), via the `fuzzedguitars` subdomain, or using the `/fuzzedguitars` path.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -234,6 +234,11 @@ def index():
 @app.route('/', subdomain='fuzzedguitars')
 def guitars_redirect():
     return redirect('https://fuzzedrecords.com/#gear', code=301)
+
+# Allow path-based access (e.g., /fuzzedguitars) for convenience
+@app.route('/fuzzedguitars')
+def guitars_redirect_path():
+    return redirect('https://fuzzedrecords.com/#gear', code=301)
     
 # Health check for uptime probes (e.g. random /robotsXYZ.txt)
 @app.route('/robots<filename>.txt')

--- a/tests/test_guitar_redirect.py
+++ b/tests/test_guitar_redirect.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import importlib
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+
+
+def test_guitar_path_redirect():
+    importlib.reload(app_module)
+    with app_module.app.test_client() as client:
+        resp = client.get('/fuzzedguitars')
+        assert resp.status_code in (301, 302)
+        assert resp.headers['Location'] == 'https://fuzzedrecords.com/#gear'


### PR DESCRIPTION
## Summary
- handle `/fuzzedguitars` path and redirect to Gear section
- mention new path-based option in README
- add regression test for path redirect

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b851ee84c8327a705487c596e5121