### PR TITLE
Expose server wallet pubkey to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Set the following environment variables to configure the application:
 - PROFILE_FETCH_TIMEOUT: Seconds to wait for a user profile event when handling `/fetch-profile` or `/validate-profile` (default: 5)
 - RELAY_CONNECT_TIMEOUT: Seconds allowed to establish each WebSocket connection to a relay (default: 2)
 - DISABLE_TLS_VERIFY: Set to 1 to disable TLS certificate verification when connecting to relays (default: 0)
+- WALLET_PRIVKEY_HEX: Hex-encoded private key for the server wallet. The corresponding
+  public key is derived automatically and exposed to the frontend as `serverWalletPubkey`.
 - VALID_PUBKEYS: Comma-separated list of pubkeys allowed for fuzzed events. If unset, the app loads from the local file specified by IDENTITIES_CACHE (default: azure_identities.json)
 - TENANT_ID: Azure AD Tenant ID for discovery JSON endpoint (/.well-known/nostr.json)
 - CLIENT_ID: Azure AD Application (client) ID

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from nostr_client import (
     RelayManager,
     Filter,
     FiltersList,
+    derive_public_key_hex,
 )
 
 def nip19_decode(value: str):
@@ -77,6 +78,11 @@ SEARCH_TERM = " by Fuzzed Records"
 PROFILE_FETCH_TIMEOUT = float(os.getenv("PROFILE_FETCH_TIMEOUT", "5"))
 RELAY_CONNECT_TIMEOUT = float(os.getenv("RELAY_CONNECT_TIMEOUT", "2"))
 DISABLE_TLS_VERIFY = os.getenv("DISABLE_TLS_VERIFY", "0").lower() in {"1", "true", "yes"}
+
+WALLET_PRIVKEY_HEX = os.getenv("WALLET_PRIVKEY_HEX", "").strip()
+SERVER_WALLET_PUBKEY = (
+    derive_public_key_hex(WALLET_PRIVKEY_HEX) if WALLET_PRIVKEY_HEX else ""
+)
 
 # Comma-separated list of pubkeys allowed to publish calendar events. If unset,
 # a local cache file specified by IDENTITIES_CACHE (default 'azure_identities.json')
@@ -229,7 +235,8 @@ register_ticket_routes(app)
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    pubkey = SERVER_WALLET_PUBKEY
+    return render_template('index.html', serverWalletPubkey=pubkey)
 
 @app.route('/', subdomain='fuzzedguitars')
 def guitars_redirect():

--- a/templates/index.html
+++ b/templates/index.html
@@ -133,6 +133,9 @@
     <script type="module" src="/static/scripts/auth.js"></script>
     <script type="module" src="/static/scripts/tracks.js"></script>
     <script type="module" src="/static/scripts/events.js"></script>
+    <script>
+      window.serverWalletPubkey = "{{ serverWalletPubkey }}";
+    </script>
     <script type="module" src="/static/scripts/ticket.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- compute server wallet pubkey from `WALLET_PRIVKEY_HEX`
- expose the pubkey in the index route and template
- document new configuration option

## Testing
- `pip install --break-system-packages --ignore-installed -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c05b0da708327a3a7994f1c1ec229