### PR TITLE
Add real ECDSA signing to Nostr events

### DIFF
--- a/tests/test_sign_verify.py
+++ b/tests/test_sign_verify.py
@@ -1,0 +1,31 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import nostr_client
+
+
+def _make_event(priv):
+    pub = nostr_client.derive_public_key_hex(priv)
+    return nostr_client.Event(
+        public_key=pub,
+        content="hello",
+        kind=nostr_client.EventKind.TEXT_NOTE,
+        tags=[],
+        created_at=123,
+    )
+
+
+def test_event_sign_and_verify():
+    priv = "11" * 32
+    ev = _make_event(priv)
+    ev.sign(priv)
+    assert ev.verify()
+
+
+def test_event_verify_fails_when_modified():
+    priv = "11" * 32
+    ev = _make_event(priv)
+    ev.sign(priv)
+    # modify content after signing
+    ev.content = "tampered"
+    assert not ev.verify()


### PR DESCRIPTION
## Summary
- implement secp256k1 signing/verification for events using `cryptography`
- ensure generated pubkeys use an even Y coordinate
- add unit tests covering valid and tampered signatures

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c092cd5a08327be09bb61437b24fd