### PR TITLE
Add TLS warning when verification disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Set the following environment variables to configure the application:
 - SEARCH_TERM: Search term used to filter Wavlake artists (default: " by Fuzzed Records")
 - PROFILE_FETCH_TIMEOUT: Seconds to wait for a user profile event when handling `/fetch-profile` or `/validate-profile` (default: 5)
 - RELAY_CONNECT_TIMEOUT: Seconds allowed to establish each WebSocket connection to a relay (default: 2)
-- DISABLE_TLS_VERIFY: Set to 1 to disable TLS certificate verification when connecting to relays (default: 0)
+- DISABLE_TLS_VERIFY: Set to 1 to disable TLS certificate verification when connecting to relays (default: 0). **Insecure - only use for testing; a warning is logged when enabled.**
 - WALLET_PRIVKEY_HEX: Hex-encoded private key for the server wallet. The corresponding
   public key is derived automatically and exposed to the frontend as `serverWalletPubkey`.
 - VALID_PUBKEYS: Comma-separated list of pubkeys allowed for fuzzed events. If unset, the app loads from the local file specified by IDENTITIES_CACHE (default: azure_identities.json)

--- a/nostr_client.py
+++ b/nostr_client.py
@@ -220,9 +220,15 @@ class RelayManager:
         self.relays[url] = _Relay(url, self.timeout)
 
     async def _connect(self, relay: _Relay, ssl_ctx):
+        disable_tls = os.getenv("DISABLE_TLS_VERIFY", "0").lower() in {"1", "true", "yes"}
         try:
             if relay.url.startswith("wss://"):
                 ssl_param = ssl_ctx if ssl_ctx is not None else True
+                if disable_tls:
+                    logger.warning(
+                        "TLS verification is disabled; connection to %s will not verify certificates",
+                        relay.url,
+                    )
             else:
                 ssl_param = None
             relay.ws = await websockets.connect(

--- a/tests/test_relay_connect_timeout.py
+++ b/tests/test_relay_connect_timeout.py
@@ -1,4 +1,4 @@
-import os, sys, importlib
+import os, sys, importlib, asyncio
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -11,3 +11,30 @@ def test_relay_connect_timeout_env(monkeypatch):
     assert app_module.RELAY_CONNECT_TIMEOUT == 6.0
     mgr = app_module.initialize_client()
     assert all(r.timeout == 6.0 for r in mgr.relays.values())
+
+
+def test_tls_disable_warning(monkeypatch, caplog):
+    monkeypatch.setenv("DISABLE_TLS_VERIFY", "1")
+    import nostr_client
+    importlib.reload(nostr_client)
+
+    async def dummy_connect(*args, **kwargs):
+        class DummyWS:
+            async def close(self):
+                pass
+
+        return DummyWS()
+
+    async def dummy_recv_loop(self, relay):
+        pass
+
+    monkeypatch.setattr(nostr_client.websockets, "connect", dummy_connect)
+    monkeypatch.setattr(nostr_client.RelayManager, "_recv_loop", dummy_recv_loop)
+
+    mgr = nostr_client.RelayManager()
+    mgr.add_relay("wss://example.com")
+
+    caplog.set_level("WARNING")
+    asyncio.run(mgr.prepare_relays())
+
+    assert any("TLS verification is disabled" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- log a warning in `nostr_client.RelayManager._connect` when `DISABLE_TLS_VERIFY` is enabled
- document risk of disabling TLS verification in README
- test that the warning is emitted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c0ac5472c83279a03db4d5c964bb3