### PR TITLE
Add Docker container setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+__pycache__/
+*.py[cod]
+.pytest_cache/
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN chmod +x startup.sh
+
+EXPOSE 8000
+
+CMD ["./startup.sh"]

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Set the following environment variables to configure the application:
    - Run `python relay_checker.py` periodically to update `good-relays.txt`.
    - On startup the app loads relays from `good-relays.txt` if present, falling back to `relays.txt` or the `RELAY_URLS` environment variable.
   - Users can contribute relays via the `/update-relays` endpoint; submitted URLs are merged in-memory and written back to `relays.txt`.
+8. **Build and Run with Docker**:
+   ```bash
+   docker build -t fuzzedrecords .
+   docker run --rm -p 8000:8000 fuzzedrecords
+   ```
+   The app will be available at http://localhost:8000.
 
 ---
 


### PR DESCRIPTION
## Summary
- add Dockerfile using python:3.11-slim
- ignore caches and tests for Docker builds
- document how to build and run the container locally

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c0c3cdcc883278d780476806783e6