### PR TITLE
Support nsec private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ Set the following environment variables to configure the application:
 - PROFILE_FETCH_TIMEOUT: Seconds to wait for a user profile event when handling `/fetch-profile` or `/validate-profile` (default: 5)
 - RELAY_CONNECT_TIMEOUT: Seconds allowed to establish each WebSocket connection to a relay (default: 2)
 - DISABLE_TLS_VERIFY: Set to 1 to disable TLS certificate verification when connecting to relays (default: 0). **Insecure - only use for testing; a warning is logged when enabled.**
-- WALLET_PRIVKEY_HEX: Hex-encoded private key for the server wallet. The corresponding
-  public key is derived automatically and exposed to the frontend as `serverWalletPubkey`.
+- WALLET_PRIVKEY_HEX: Private key for the server wallet. May be provided as a hex
+  string or NIP-19 `nsec` value. The corresponding public key is derived automatically
+  and exposed to the frontend as `serverWalletPubkey`.
 - VALID_PUBKEYS: Comma-separated list of pubkeys allowed for fuzzed events. If unset, the app loads from the local file specified by IDENTITIES_CACHE (default: azure_identities.json)
 - TENANT_ID: Azure AD Tenant ID for discovery JSON endpoint (/.well-known/nostr.json)
 - CLIENT_ID: Azure AD Application (client) ID

--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ from nostr_client import (
     Filter,
     FiltersList,
     derive_public_key_hex,
+    nsec_to_hex,
 )
 
 def nip19_decode(value: str):
@@ -79,7 +80,16 @@ PROFILE_FETCH_TIMEOUT = float(os.getenv("PROFILE_FETCH_TIMEOUT", "5"))
 RELAY_CONNECT_TIMEOUT = float(os.getenv("RELAY_CONNECT_TIMEOUT", "2"))
 DISABLE_TLS_VERIFY = os.getenv("DISABLE_TLS_VERIFY", "0").lower() in {"1", "true", "yes"}
 
-WALLET_PRIVKEY_HEX = os.getenv("WALLET_PRIVKEY_HEX", "").strip()
+_privkey_env = os.getenv("WALLET_PRIVKEY_HEX", "").strip()
+if _privkey_env.startswith("nsec"):
+    try:
+        WALLET_PRIVKEY_HEX = nsec_to_hex(_privkey_env)
+    except Exception:
+        logger.error("Invalid nsec key provided for WALLET_PRIVKEY_HEX")
+        WALLET_PRIVKEY_HEX = ""
+else:
+    WALLET_PRIVKEY_HEX = _privkey_env
+
 SERVER_WALLET_PUBKEY = (
     derive_public_key_hex(WALLET_PRIVKEY_HEX) if WALLET_PRIVKEY_HEX else ""
 )

--- a/nostr_client.py
+++ b/nostr_client.py
@@ -67,6 +67,14 @@ def npub_to_hex(value: str) -> str:
     decoded = bech32.convertbits(data, 5, 8, False)
     return bytes(decoded).hex()
 
+def nsec_to_hex(value: str) -> str:
+    """Decode a bech32 ``nsec`` string into a hex private key."""
+    hrp, data = bech32.bech32_decode(value)
+    if hrp != "nsec" or data is None:
+        raise ValueError("Invalid nsec")
+    decoded = bech32.convertbits(data, 5, 8, False)
+    return bytes(decoded).hex()
+
 # --- Event and Filters ---
 
 class EventKind:

--- a/tests/test_nsec_support.py
+++ b/tests/test_nsec_support.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import importlib
+import bech32
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import nostr_client
+
+
+def _encode_nsec(hex_key: str) -> str:
+    words = bech32.convertbits(bytes.fromhex(hex_key), 8, 5)
+    return bech32.bech32_encode("nsec", words)
+
+
+def test_nsec_env(monkeypatch):
+    hex_key = "11" * 32
+    nsec = _encode_nsec(hex_key)
+    monkeypatch.setenv("WALLET_PRIVKEY_HEX", nsec)
+    import app as app_module
+    importlib.reload(app_module)
+    assert app_module.WALLET_PRIVKEY_HEX == hex_key
+    assert app_module.SERVER_WALLET_PUBKEY
+
+
+def test_nsec_to_hex_roundtrip():
+    priv_hex = "22" * 32
+    nsec = _encode_nsec(priv_hex)
+    assert nostr_client.nsec_to_hex(nsec) == priv_hex
+


### PR DESCRIPTION
## Summary
- add `nsec_to_hex` helper
- allow `WALLET_PRIVKEY_HEX` env var to accept nsec encoded value
- document new option in README
- test nsec handling for env variable and converter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c2c73c0748327b4951a2cbd939901