### PR TITLE
Validate pubkey and content in ticket endpoint

### DIFF
--- a/tests/test_send_ticket_endpoint_validation.py
+++ b/tests/test_send_ticket_endpoint_validation.py
@@ -8,22 +8,27 @@ import app as app_module
 import ticket_utils
 
 
-def test_send_ticket_endpoint_invalid_cipher(monkeypatch):
+def test_send_ticket_endpoint_invalid_pubkey(monkeypatch):
     monkeypatch.setattr(ticket_utils, "wallet_priv_hex", "11" * 32)
-
-    def bad_decrypt(priv, pub, cipher):
-        raise ValueError("bad cipher")
-
-    monkeypatch.setattr(ticket_utils, "nip44_decrypt", bad_decrypt)
-
     with app_module.app.test_client() as client:
         resp = client.post(
             "/send_ticket",
             json={
                 "id": "1",
-                "pubkey": "a" * 64,
+                "pubkey": "abc",
                 "content": base64.b64encode(b"cipher").decode(),
             },
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "Invalid pubkey"
+
+
+def test_send_ticket_endpoint_invalid_content(monkeypatch):
+    monkeypatch.setattr(ticket_utils, "wallet_priv_hex", "11" * 32)
+    with app_module.app.test_client() as client:
+        resp = client.post(
+            "/send_ticket",
+            json={"id": "1", "pubkey": "a" * 64, "content": "bad"},
         )
         assert resp.status_code == 400
         assert resp.get_json()["error"] == "Invalid encrypted payload"

--- a/ticket_utils.py
+++ b/ticket_utils.py
@@ -1,4 +1,4 @@
-import time, json, asyncio, os, binascii
+import time, json, asyncio, os, binascii, base64, re
 from io import BytesIO
 import qrcode
 from flask import request, jsonify
@@ -104,6 +104,14 @@ def register_ticket_routes(app):
         wallet_priv = wallet_priv_hex
         if not wallet_priv:
             return error_response("Server wallet not configured", 500)
+
+        if not re.fullmatch(r"[0-9a-fA-F]{64}", sender_pub):
+            return error_response("Invalid pubkey", 400)
+
+        try:
+            base64.b64decode(cipher, validate=True)
+        except (ValueError, binascii.Error):
+            return error_response("Invalid encrypted payload", 400)
 
         try:
             plain = nip44_decrypt(wallet_priv, sender_pub, cipher)


### PR DESCRIPTION
## Summary
- ensure `/send_ticket` rejects non-hex pubkeys and invalid base64 content before decrypting
- add tests for pubkey and content validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d77715a4c8327845b365d7778bc6d