### PR TITLE
Use Hypercorn ASGI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Fuzzed Records is a modern music platform that integrates decentralized authenti
 - **QR Code Ticketing**: Generate QR code tickets for live music events, sent via Nostr DM to users.
 - **Prices in USD and Sats**: Event listings display prices in both dollars and satoshis.
 - **Efficient Data Caching**: Utilizes caching for optimizing data retrieval performance.
-- **Rate Limiting**: Protects API endpoints using Flask-Limiter with optional Azure Table Storage backend.
-- **CORS Configuration**: Allowed origins can be customized via environment variable.
+- **Rate Limiting**: Protects API endpoints using Flask-Limiter with optional Azure Table Storage backend (ASGI-compatible).
+- **CORS Configuration**: Allowed origins can be customized via environment variable (Flask-CORS works under Hypercorn).
 - **Section Links**: Use URL hashes like `/#gear` to open a specific section directly.
 - **Fuzzed Guitars**: Boutique gear prototypes can be viewed in the Gear section (`/#gear`), via the `fuzzedguitars` subdomain, or using the `/fuzzedguitars` path.
 
@@ -48,7 +48,7 @@ Fuzzed Records is a modern music platform that integrates decentralized authenti
   - NIP-05 verification for admin access
 - **Hosting**:
   - Microsoft Azure
-  - Gunicorn as WSGI server
+  - Hypercorn ASGI server
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests>=2.32.0
 msal>=1.22.0
 flask-limiter>=2.0.0
 qrcode==7.4.2
-gunicorn>=20.1.0
+hypercorn>=0.14.4
 azure-data-tables>=12.6.0
 pytest>=7.4
 websockets>=15.0

--- a/startup.sh
+++ b/startup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Install dependencies (ensures msal, gunicorn, and other packages are available)
+# Install dependencies (ensures msal, hypercorn, and other packages are available)
 pip install --no-cache-dir -r requirements.txt
 
-# Launch Gunicorn WSGI server
-exec gunicorn --bind=0.0.0.0:8000 \
+# Launch Hypercorn ASGI server
+exec hypercorn --bind 0.0.0.0:8000 \
     --log-level debug \
     --access-logfile - \
     --error-logfile - \


### PR DESCRIPTION
## Summary
- switch deployment to Hypercorn ASGI server
- document ASGI server and middleware compatibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d7a3a7b908327b523e5a165d20d50