### PR TITLE
Refactor Nostr routes to synchronous handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ If dependencies are missing, tests will fail with import errors similar to the o
 
 ## API Endpoints
 
+All backend routes are now synchronous Flask handlers. Asynchronous Nostr operations are executed internally using `asyncio.run()`, so clients interact with a standard blocking HTTP API.
+
 ### 0. Nostr Discovery JSON
 - **Endpoint**: `/.well-known/nostr.json`
 - **Method**: `GET`


### PR DESCRIPTION
## Summary
- Convert Nostr profile, event creation, and event feed routes to synchronous `def` functions and execute async work with `asyncio.run`
- Refactor ticket sending endpoint to a synchronous view using `asyncio.run`
- Document that backend routes now expose a synchronous API while still leveraging asyncio internally

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d7c282840832789be72d09a8f9173