### PR TITLE
Honor SEARCH_TERM environment variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,7 +75,7 @@ REQUIRED_DOMAIN = os.getenv("REQUIRED_DOMAIN", "fuzzedrecords.com")
 # Base URL for Wavlake API; can be overridden via environment
 # Default updated to use wavlake.com domain as per API docs
 WAVLAKE_API_BASE = os.getenv("WAVLAKE_API_BASE", "https://wavlake.com/api/v1")
-SEARCH_TERM = " by Fuzzed Records"
+SEARCH_TERM = os.getenv("SEARCH_TERM", " by Fuzzed Records")
 PROFILE_FETCH_TIMEOUT = float(os.getenv("PROFILE_FETCH_TIMEOUT", "5"))
 RELAY_CONNECT_TIMEOUT = float(os.getenv("RELAY_CONNECT_TIMEOUT", "2"))
 DISABLE_TLS_VERIFY = os.getenv("DISABLE_TLS_VERIFY", "0").lower() in {"1", "true", "yes"}

--- a/tests/test_build_music_library.py
+++ b/tests/test_build_music_library.py
@@ -15,10 +15,13 @@ class DummyResponse:
 
 
 def test_build_music_library(monkeypatch):
+    monkeypatch.setenv('SEARCH_TERM', ' by Fuzzed Records')
+    search_term = os.getenv('SEARCH_TERM', ' by Fuzzed Records')
+
     # Provide a minimal stub for the app module to avoid circular imports
     stub_app = type('app', (), {
         'WAVLAKE_API_BASE': 'https://wavlake.com/api/v1',
-        'SEARCH_TERM': ' by Fuzzed Records',
+        'SEARCH_TERM': search_term,
         'error_response': lambda msg, code: None,
     })()
     monkeypatch.setitem(sys.modules, 'app', stub_app)
@@ -31,14 +34,14 @@ def test_build_music_library(monkeypatch):
     tracks = [
         {
             "id": "track1",
-            "artist": "Test Artist by Fuzzed Records",
+            "artist": f"Test Artist{search_term}",
             "albumTitle": "Test Album",
             "title": "Track One",
             "mediaUrl": "url1",
         },
         {
             "id": "track2",
-            "artist": "Test Artist by Fuzzed Records",
+            "artist": f"Test Artist{search_term}",
             "albumTitle": "Test Album",
             "title": "Track Two",
             "mediaUrl": "url2",


### PR DESCRIPTION
## Summary
- pull `SEARCH_TERM` from `os.getenv` allowing runtime overrides
- adjust unit test to source `SEARCH_TERM` from the environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d7fcd7d5c832794d216190fd591c6