### PR TITLE
Cache RelayManager connections and reuse via pooled context

### DIFF
--- a/tests/test_relay_manager_pool.py
+++ b/tests/test_relay_manager_pool.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import app
+
+
+class DummyRelayManager:
+    def __init__(self, timeout=None):
+        self.timeout = timeout
+        self.relays = {}
+        self.prepare_count = 0
+        self.closed = False
+
+    def add_relay(self, url):
+        self.relays[url] = object()
+
+    async def prepare_relays(self):
+        self.prepare_count += 1
+
+    async def publish_event(self, ev):
+        pass
+
+    async def close_connections(self):
+        self.closed = True
+
+
+def test_manager_reuse(monkeypatch):
+    asyncio.run(app.close_relay_managers())
+    monkeypatch.setattr(app, "_pool_started", True)
+    monkeypatch.setattr(app, "RelayManager", DummyRelayManager)
+
+    async def run_test():
+        mgr1 = await app.get_relay_manager()
+        await app.release_relay_manager(mgr1)
+        mgr2 = await app.get_relay_manager()
+        await app.release_relay_manager(mgr2)
+        assert mgr1 is mgr2
+        assert mgr1.prepare_count == 1
+
+    asyncio.run(run_test())
+
+
+def test_shutdown_closes_connections(monkeypatch):
+    asyncio.run(app.close_relay_managers())
+    monkeypatch.setattr(app, "_pool_started", True)
+    monkeypatch.setattr(app, "RelayManager", DummyRelayManager)
+
+    async def run_test():
+        mgr = await app.get_relay_manager()
+        await app.release_relay_manager(mgr)
+        await app.close_relay_managers()
+        assert mgr.closed
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- add relay manager pool with `get_relay_manager`, `release_relay_manager`, and async context manager for reuse
- lazily start pool and close all connections on shutdown
- update Nostr and ticket utilities to borrow managers without closing connections, and add tests for pool reuse and shutdown

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d7eae3c288327a65645f2af402b88