### PR TITLE
Ensure RelayManager reinitializes per request

### DIFF
--- a/tests/test_relay_manager_pool.py
+++ b/tests/test_relay_manager_pool.py
@@ -34,7 +34,10 @@ def test_manager_reuse(monkeypatch):
         mgr2 = await app.get_relay_manager()
         await app.release_relay_manager(mgr2)
         assert mgr1 is mgr2
-        assert mgr1.prepare_count == 1
+        # Each borrow prepares relays, so count increments twice.
+        assert mgr1.prepare_count == 2
+        # Connections should be closed when released back to the pool.
+        assert mgr1.closed
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- always prepare relays when borrowing from pool to bind websocket connections to the current event loop
- close existing connections when releasing to avoid stale relays
- update pool tests for new reconnect behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d8579cf4883278f4f927595efc76a