### PR TITLE
Handle closed event loop in RelayManager

### DIFF
--- a/nostr_client.py
+++ b/nostr_client.py
@@ -321,10 +321,17 @@ class RelayManager:
                     await r.ws.close()
                 except Exception:
                     pass
+        alive_tasks = []
         for task in self._recv_tasks:
             task.cancel()
-        if self._recv_tasks:
-            await asyncio.gather(*self._recv_tasks, return_exceptions=True)
+            try:
+                if task.get_loop().is_closed():
+                    continue
+            except Exception:
+                continue
+            alive_tasks.append(task)
+        if alive_tasks:
+            await asyncio.gather(*alive_tasks, return_exceptions=True)
         self._recv_tasks.clear()
 
 _P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F


### PR DESCRIPTION
## Summary
- avoid gathering websocket receiver tasks whose event loop has been closed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d877b46cc8327b0170bfdb6fedfdc