### PR TITLE
Ensure Lightning wallet present before confirming ticket

### DIFF
--- a/static/scripts/ticket.js
+++ b/static/scripts/ticket.js
@@ -12,16 +12,19 @@ async function purchaseTicket(eventData) {
     });
     const data = await resp.json();
     if (!resp.ok) throw new Error(data.error || 'Failed to create invoice');
-    if (window.webln) {
-      try {
-        await window.webln.enable?.();
-        await window.webln.sendPayment(data.invoice);
-      } catch (err) {
-        console.error('Payment failed', err);
-        alert('Payment failed');
-        return;
-      }
+    if (!window.webln) {
+      alert('Lightning wallet not available');
+      return;
     }
+    try {
+      await window.webln.enable?.();
+      await window.webln.sendPayment(data.invoice);
+    } catch (err) {
+      console.error('Payment failed', err);
+      alert('Payment failed');
+      return;
+    }
+
     const confirmResp = await fetch('/confirm-payment', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Require WebLN support before calling `/confirm-payment`
- Prompt users without a Lightning wallet instead of sending tickets for free

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e493541a88327a215c3f5f8d92eb4