### PR TITLE
Switch to BIP340 Schnorr signatures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest>=7.4
 websockets>=15.0
 cryptography>=42.0
 PyNaCl>=1.5
+secp256k1>=0.14.0


### PR DESCRIPTION
## Summary
- replace DER-encoded ECDSA signatures with BIP-340 Schnorr `r||s`
- verify events using Schnorr keys via libsecp256k1
- add secp256k1 dependency

## Testing
- `pytest`
- `python - <<'PY'
import nostr_client
priv='11'*32
pub=nostr_client.derive_public_key_hex(priv)
ev=nostr_client.Event(public_key=pub, content='hello', created_at=123)
ev.sign(priv)
print('sig length', len(ev.sig))
print('verify', ev.verify())
PY`
- Attempted to publish signed event to `wss://relay.damus.io` (blocked: server rejected WebSocket connection: HTTP 403)


------
https://chatgpt.com/codex/tasks/task_e_688e532d863c8327b2e82a214ba5648c