### PR TITLE
Log ticket relay WebSocket failures

### DIFF
--- a/static/scripts/ticket.js
+++ b/static/scripts/ticket.js
@@ -84,6 +84,14 @@ function subscribeForTickets() {
         console.error('Failed to process ticket event', err);
       }
     };
+    ws.onerror = err => {
+      console.error('Ticket relay websocket error', url, err);
+      if (typeof alert === 'function') alert('Ticket relay connection error. Retrying...');
+    };
+    ws.onclose = evt => {
+      console.error('Ticket relay websocket closed', url, evt);
+      setTimeout(subscribeForTickets, 5000);
+    };
   });
 }
 


### PR DESCRIPTION
## Summary
- log WebSocket errors and disconnects for ticket relays
- alert users and retry on relay connection failures

## Testing
- `node - <<'NODE' ...` (error simulation)
- `node - <<'NODE' ...` (close simulation)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e557800688327b198ad7db4b4c623