### PR TITLE
Install secp256k1 build deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt ./
+RUN apt-get update && \
+    apt-get install -y pkg-config libsecp256k1-dev && \
+    rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
## Summary
- add system packages required for `secp256k1` build in Dockerfile

## Testing
- `pytest`
- `docker build -t fuzzedrecords-web .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_688e633696dc83278a35bb2262b7a015