### PR TITLE
Handle dependency install failures in startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
+set -e
 
 # Install dependencies (ensures msal, hypercorn, and other packages are available)
-pip install --no-cache-dir -r requirements.txt
+pip install --no-cache-dir -r requirements.txt || {
+    echo "Error: Failed to install dependencies." >&2
+    exit 1
+}
 
 # Launch Hypercorn ASGI server
 exec hypercorn --bind 0.0.0.0:8000 \


### PR DESCRIPTION
## Summary
- fail fast in `startup.sh` with `set -e`
- surface a clear error when dependency installation fails

## Testing
- `pytest`
- `bash startup.sh` with missing `requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688e65bbb1248327b3b3949c26a04049