### PR TITLE
Ensure secp256k1 system deps in startup

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -e
 
-# Install dependencies (ensures msal, hypercorn, and other packages are available)
+# Ensure system packages needed for secp256k1 are installed
+if ! command -v pkg-config >/dev/null 2>&1; then
+    apt-get update && \
+    apt-get install -y pkg-config libsecp256k1-dev && \
+    rm -rf /var/lib/apt/lists/*
+fi
+
+# Install Python dependencies (ensures msal, hypercorn, and other packages are available)
 pip install --no-cache-dir -r requirements.txt || {
     echo "Error: Failed to install dependencies." >&2
     exit 1


### PR DESCRIPTION
## Summary
- Install pkg-config and libsecp256k1-dev in startup script when missing
- Maintain existing dependency installation and server launch

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e89ce30248327af97b9b34745d24d