### PR TITLE
Ensure build tools available for secp256k1

### DIFF
--- a/.github/workflows/main_fuzzedrecords-web.yml
+++ b/.github/workflows/main_fuzzedrecords-web.yml
@@ -28,6 +28,11 @@ jobs:
           source antenv/bin/activate
           echo "PYTHONPATH=$(pwd)/antenv/lib/python3.11/site-packages" >> $GITHUB_ENV
 
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
       - name: Install dependencies
         run: |
           source antenv/bin/activate

--- a/startup.sh
+++ b/startup.sh
@@ -4,7 +4,7 @@ set -e
 # Ensure system packages needed for secp256k1 are installed
 if ! command -v pkg-config >/dev/null 2>&1; then
     apt-get update && \
-    apt-get install -y pkg-config libsecp256k1-dev && \
+    apt-get install -y build-essential pkg-config libsecp256k1-dev && \
     rm -rf /var/lib/apt/lists/*
 fi
 


### PR DESCRIPTION
## Summary
- install build-essential in CI workflow to support building secp256k1
- provision build-essential on startup so deployment container can compile secp256k1

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e8d1aba8883279262658812f14015