### PR TITLE
Replace secp256k1 with coincurve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN apt-get update && \
-    apt-get install -y pkg-config libsecp256k1-dev && \
-    rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pytest>=7.4
 websockets>=15.0
 cryptography>=42.0
 PyNaCl>=1.5
-secp256k1>=0.14.0
+coincurve>=21.0.0

--- a/startup.sh
+++ b/startup.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 set -e
 
-# Ensure system packages needed for secp256k1 are installed
-if ! command -v pkg-config >/dev/null 2>&1; then
-    apt-get update && \
-    apt-get install -y build-essential pkg-config libsecp256k1-dev && \
-    rm -rf /var/lib/apt/lists/*
-fi
-
 # Install Python dependencies (ensures msal, hypercorn, and other packages are available)
 pip install --no-cache-dir -r requirements.txt || {
     echo "Error: Failed to install dependencies." >&2


### PR DESCRIPTION
## Summary
- use coincurve for Schnorr signing and verification
- drop system-level secp256k1 dependencies from Dockerfile and startup script
- update requirements to include coincurve

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d265560c83279842f1e37e60169f