### PR TITLE
Ensure coincurve native extension available at runtime

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 set -e
 
-# Install Python dependencies (ensures msal, hypercorn, and other packages are available)
+# Remove any stale local copies of coincurve that could shadow the installed package
+rm -rf coincurve
+
+# Install Python dependencies (ensures msal, hypercorn, coincurve, and other packages are available)
 pip install --no-cache-dir -r requirements.txt || {
     echo "Error: Failed to install dependencies." >&2
+    exit 1
+}
+
+# Reinstall coincurve to ensure native extension is present
+pip install --no-cache-dir --force-reinstall coincurve || {
+    echo "Error: Failed to reinstall coincurve." >&2
     exit 1
 }
 


### PR DESCRIPTION
## Summary
- guarantee coincurve installs its native extension on startup
- clear out any leftover coincurve sources before installing dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890d77fe9f0832793d09e681f65f2f0