### PR TITLE
Add gear submenu with multiple prototype options

### DIFF
--- a/static/scripts/gear.js
+++ b/static/scripts/gear.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const buttons = document.querySelectorAll('.gear-submenu button');
+  const items = document.querySelectorAll('#gear-items .gear-item');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = btn.dataset.target;
+      items.forEach(item => {
+        item.classList.toggle('active', item.id === target);
+      });
+      buttons.forEach(b => b.classList.toggle('active', b === btn));
+    });
+  });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -217,6 +217,41 @@ footer {
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.2);
 }
 
+.gear-submenu {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin: 10px auto;
+}
+
+.gear-submenu button {
+    padding: 10px 15px;
+    background-color: #555;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.gear-submenu button:hover {
+    background-color: #777;
+}
+
+.gear-submenu button.active {
+    background-color: #999;
+}
+
+#gear-items .gear-item {
+    display: none;
+    margin-top: 15px;
+}
+
+#gear-items .gear-item.active {
+    display: block;
+}
+
 /* Profile section styling */
 #profile-section {
     border: 1px solid #ddd;

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,6 +43,22 @@
 
         <section id="gear-section" class="content-section">
             <p>Boutique gear crafted for experimental sound.</p>
+            <nav class="gear-submenu">
+                <button class="gear-btn active" data-target="gear-jaguar">Fuzzed Jaguar</button>
+                <button class="gear-btn" data-target="gear-alpha">Fuzzed Alpha 0.1</button>
+                <button class="gear-btn" data-target="gear-beta">Fuzzed Beta 0.5</button>
+            </nav>
+            <div id="gear-items">
+                <div id="gear-jaguar" class="gear-item active">
+                    <p>Details for Fuzzed Jaguar coming soon.</p>
+                </div>
+                <div id="gear-alpha" class="gear-item">
+                    <p>Details for Fuzzed Alpha 0.1 coming soon.</p>
+                </div>
+                <div id="gear-beta" class="gear-item">
+                    <p>Details for Fuzzed Beta 0.5 coming soon.</p>
+                </div>
+            </div>
             <div class="gear-container">
                 <img src="/static/images/lasered-fuzzed-guitars.jfif" alt="Fuzzed Guitars" class="gear-photo">
             </div>
@@ -130,14 +146,15 @@
         <p>© 2025 Fuzzed Records. All rights reserved.</p>
     </footer>
 
-    <script type="module" src="/static/scripts/auth.js"></script>
-    <script type="module" src="/static/scripts/tracks.js"></script>
-    <script type="module" src="/static/scripts/events.js"></script>
-    <script>
-      window.serverWalletPubkey = "{{ serverWalletPubkey }}";
-    </script>
-    <script type="module" src="/static/scripts/ticket.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+      <script type="module" src="/static/scripts/auth.js"></script>
+      <script type="module" src="/static/scripts/tracks.js"></script>
+      <script type="module" src="/static/scripts/events.js"></script>
+      <script type="module" src="/static/scripts/gear.js"></script>
+      <script>
+        window.serverWalletPubkey = "{{ serverWalletPubkey }}";
+      </script>
+      <script type="module" src="/static/scripts/ticket.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Add submenu under Gear section featuring Fuzzed Jaguar, Fuzzed Alpha 0.1, and Fuzzed Beta 0.5
- Style submenu and gear items for clarity
- Include gear.js module to handle submenu interaction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a31e730e88832791e73b8aa0b93296