### PR TITLE
Add image galleries to gear items

### DIFF
--- a/static/scripts/gear.js
+++ b/static/scripts/gear.js
@@ -10,4 +10,31 @@ document.addEventListener('DOMContentLoaded', () => {
       buttons.forEach(b => b.classList.toggle('active', b === btn));
     });
   });
+
+  document.querySelectorAll('.gear-gallery').forEach(gallery => {
+    const images = gallery.querySelectorAll('img');
+    const prev = gallery.querySelector('.prev');
+    const next = gallery.querySelector('.next');
+    const caption = gallery.parentElement.querySelector('.gear-caption');
+    let index = 0;
+
+    const showImage = i => {
+      images.forEach((img, idx) => img.classList.toggle('active', idx === i));
+      if (caption) {
+        caption.textContent = images[i].alt;
+      }
+    };
+
+    prev.addEventListener('click', () => {
+      index = (index - 1 + images.length) % images.length;
+      showImage(index);
+    });
+
+    next.addEventListener('click', () => {
+      index = (index + 1) % images.length;
+      showImage(index);
+    });
+
+    showImage(index);
+  });
 });

--- a/static/style.css
+++ b/static/style.css
@@ -269,11 +269,50 @@ footer {
     margin: 10px auto;
 }
 
+.gear-gallery {
+    max-width: 300px;
+    width: 100%;
+    margin: 10px auto;
+    position: relative;
+}
+
+.gear-gallery img {
+    display: none;
+}
+
+.gear-gallery img.active {
+    display: block;
+}
+
+.gallery-controls {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 5px;
+}
+
+.gallery-controls button {
+    padding: 5px 10px;
+    background-color: #555;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.gallery-controls button:hover {
+    background-color: #777;
+}
+
 .gear-photo {
     width: 100%;
     height: auto;
     object-fit: contain;
     display: block;
+}
+
+.gear-caption {
+    margin: 10px auto;
 }
 
 @media (min-width: 768px) {
@@ -283,6 +322,9 @@ footer {
     }
 
     .gear-container {
+        max-width: 350px;
+    }
+    .gear-gallery {
         max-width: 350px;
     }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,30 +50,40 @@
             </nav>
             <div id="gear-items">
                 <div id="gear-jaguar" class="gear-item active">
-                    <div class="gear-container">
-                        <img src="/static/images/jaguar.jfif" alt="Fuzzed Jaguar" class="gear-photo">
+                    <div class="gear-gallery">
+                        <img src="/static/images/jaguar.jfif" alt="It is coming together…" class="gear-photo">
+                        <img src="/static/images/fuzzed-jaguar-body-painted.jfif" alt="Body painted" class="gear-photo">
+                        <img src="/static/images/fuzzed-jaguar-body-routed.jfif" alt="Body routed" class="gear-photo">
+                        <img src="/static/images/fuzzed-jaguar-final.jfif" alt="Final build" class="gear-photo">
+                        <img src="/static/images/fuzzed-jaguar-neck-truss.jfif" alt="Neck truss install" class="gear-photo">
+                        <div class="gallery-controls">
+                            <button class="prev">❮</button>
+                            <button class="next">❯</button>
+                        </div>
                     </div>
-                    <p>It is coming together…</p>
+                    <p class="gear-caption"></p>
                 </div>
                 <div id="gear-alpha" class="gear-item">
-                    <div class="gear-container">
+                    <div class="gear-gallery">
                         <img src="/static/images/pre-alpha01.jfif" alt="restoration project as the alpha for a custom project." class="gear-photo">
-                    </div>
-                    <p>restoration project as the alpha for a custom project.</p>
-                    <div class="gear-container">
                         <img src="/static/images/almost-alpha01.jfif" alt="Almost there…" class="gear-photo">
+                        <div class="gallery-controls">
+                            <button class="prev">❮</button>
+                            <button class="next">❯</button>
+                        </div>
                     </div>
-                    <p>Almost there…</p>
+                    <p class="gear-caption"></p>
                 </div>
                 <div id="gear-beta" class="gear-item">
-                    <div class="gear-container">
+                    <div class="gear-gallery">
                         <img src="/static/images/silhouette-beta05.jfif" alt="The Idea and inspiration" class="gear-photo">
-                    </div>
-                    <p>The Idea and inspiration</p>
-                    <div class="gear-container">
                         <img src="/static/images/template-beta05-body.jfif" alt="Poplar and Template ready to go…" class="gear-photo">
+                        <div class="gallery-controls">
+                            <button class="prev">❮</button>
+                            <button class="next">❯</button>
+                        </div>
                     </div>
-                    <p>Poplar and Template ready to go…</p>
+                    <p class="gear-caption"></p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- turn each gear item into an image gallery with navigation controls
- hook up gallery logic to update captions per picture
- style galleries and integrate new Fuzzed Jaguar build photos

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0feaed58832794f80c88f2670eea