### PR TITLE
Add static shop page with Lightning payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Fuzzed Records is a modern music platform that integrates decentralized authenti
 - **CORS Configuration**: Allowed origins can be customized via environment variable (Flask-CORS works under Hypercorn).
 - **Section Links**: Use URL hashes like `/#gear` to open a specific section directly.
 - **Fuzzed Guitars**: Boutique gear prototypes can be viewed in the Gear section (`/#gear`), via the `fuzzedguitars` subdomain, or using the `/fuzzedguitars` path.
+- **Shop**: After Nostr login, visit `/shop` to browse custom guitars and pay via Lightning.
 
 ---
 

--- a/static/scripts/shop.js
+++ b/static/scripts/shop.js
@@ -1,0 +1,61 @@
+// shop.js - handle shop navigation and Lightning payments
+
+function showShopButton() {
+  const menuShop = document.getElementById('menu-shop');
+  if (menuShop) {
+    menuShop.style.display = 'inline-block';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const menuProfile = document.getElementById('menu-profile');
+  const menuShop = document.getElementById('menu-shop');
+
+  // Navigate to shop when clicking the button on index page
+  if (menuShop) {
+    menuShop.addEventListener('click', () => {
+      window.location.href = '/shop';
+    });
+  }
+
+  // Show shop button if already logged in
+  if (sessionStorage.getItem('pubkey')) {
+    showShopButton();
+  }
+
+  // Observe login state to reveal shop button after login
+  if (menuProfile) {
+    const observer = new MutationObserver(() => {
+      if (menuProfile.dataset.loggedIn === 'true') {
+        showShopButton();
+        observer.disconnect();
+      }
+    });
+    observer.observe(menuProfile, { attributes: true, attributeFilter: ['data-logged-in'] });
+  }
+
+  // Shop page payment handling and access control
+  const lightningAddrElem = document.getElementById('lightning-address');
+  if (lightningAddrElem) {
+    // Redirect to home if not logged in
+    if (!sessionStorage.getItem('pubkey')) {
+      window.location.href = '/';
+      return;
+    }
+
+    const addr = lightningAddrElem.textContent;
+    const copyBtn = document.getElementById('copy-lightning');
+    if (copyBtn) {
+      copyBtn.addEventListener('click', () => {
+        navigator.clipboard.writeText(addr);
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => (copyBtn.textContent = 'Copy'), 2000);
+      });
+    }
+
+    const qrEl = document.getElementById('lightning-qr');
+    if (qrEl && window.QRCode) {
+      new QRCode(qrEl, addr);
+    }
+  }
+});

--- a/static/style.css
+++ b/static/style.css
@@ -126,16 +126,6 @@ body {
     margin: 20px auto;
 }
 
-.event-item {
-    border: 1px solid #ddd;
-    border-radius: 5px;
-    padding: 10px;
-    margin: 20px auto;
-    max-width: 500px;
-    background: #f9f9f9;
-    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.2);
-}
-
 .external-logo {
     width: 20px;
     height: 20px;
@@ -319,4 +309,24 @@ footer {
     .gear-gallery {
         max-width: 350px;
     }
+}
+
+/* Shop page styling */
+.shop-item {
+    margin: 20px auto;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    max-width: 500px;
+    background: #f9f9f9;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.lightning-payment {
+    margin: 20px auto;
+    max-width: 500px;
+}
+
+#lightning-qr {
+    margin: 20px auto;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,6 +19,7 @@
     <nav class="menu">
         <button id="menu-library" class="nav-btn active">Library</button>
         <button id="menu-gear" class="nav-btn">Gear</button>
+        <button id="menu-shop" class="nav-btn" style="display: none;">Shop</button>
         <!-- Profile button is always visible so the user can trigger login -->
         <button id="menu-profile" class="nav-btn">Nostr Login</button>
     </nav>
@@ -124,6 +125,7 @@
       <script type="module" src="/static/scripts/auth.js"></script>
       <script type="module" src="/static/scripts/tracks.js"></script>
       <script type="module" src="/static/scripts/gear.js"></script>
+      <script type="module" src="/static/scripts/shop.js"></script>
       <script>
         window.serverWalletPubkey = "{{ serverWalletPubkey }}";
       </script>

--- a/templates/shop.html
+++ b/templates/shop.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fuzzed Records - Shop</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <div class="logo-container">
+            <img id="header-logo" src="/static/images/fuzzedrecords.png" alt="Fuzzed Records Logo" class="logo">
+        </div>
+    </header>
+
+    <nav class="menu">
+        <a id="menu-library" class="nav-btn" href="/">Library</a>
+        <a id="menu-gear" class="nav-btn" href="/#gear">Gear</a>
+        <button id="menu-shop" class="nav-btn active">Shop</button>
+        <!-- Profile button is always visible so the user can trigger login -->
+        <button id="menu-profile" class="nav-btn">Nostr Login</button>
+    </nav>
+
+    <main>
+        <section id="shop-section" class="content-section active">
+            <h2>Custom Guitars</h2>
+            <div class="shop-item">
+                <p>Fuzzed custom guitars built to order. Reach out via Nostr or email to start your build.</p>
+            </div>
+            <div class="lightning-payment">
+                <p>Send sats to our Lightning Address:</p>
+                <div>
+                    <span id="lightning-address">fuzzedguitars@fuzzedrecords.com</span>
+                    <button id="copy-lightning">Copy</button>
+                    <a id="lnurl-link" href="lightning:fuzzedguitars@fuzzedrecords.com">Pay</a>
+                </div>
+                <div id="lightning-qr"></div>
+            </div>
+        </section>
+
+        <section id="profile-section">
+            <h2>Profile Details</h2>
+            <div id="profile-container">
+                <p class="empty-profile">
+                    No profile information available. Please authenticate with a Nostr NIP-07 capable wallet such as
+                    <a href="https://getalby.com/products/browser-extension" target="_blank" rel="noopener noreferrer">
+                        <img src="/static/images/thumb_Alby-logo-figure-400.png" alt="Alby Logo" class="inline-icon">Alby
+                    </a>
+                    after you create a Nostr account using one of the many clients such as
+                    <a href="https://damus.io" target="_blank" rel="noopener noreferrer">
+                        <img src="/static/images/damus.png" alt="Damus Logo" class="inline-icon">Damus (for iOS)
+                    </a> or
+                    <a href="https://primal.net" target="_blank" rel="noopener noreferrer">
+                        <img src="/static/images/primal_400x400.png" alt="Primal Logo" class="inline-icon">Primal (for iOS or Android or Desktop)
+                    </a>.
+                </p>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>© 2025 Fuzzed Records. All rights reserved.</p>
+    </footer>
+
+    <script type="module" src="/static/scripts/auth.js"></script>
+    <script type="module" src="/static/scripts/shop.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Shop link gated behind Nostr login
- create static shop page with Lightning address copy/QR and LNURL deep link
- clean up event UI and document new shop in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb6707412083279f00630de1f3a8a3