### PR TITLE
Add shop route and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -320,6 +320,12 @@ def index():
     pubkey = SERVER_WALLET_PUBKEY
     return render_template('index.html', serverWalletPubkey=pubkey)
 
+@app.route('/shop')
+def shop():
+    """Render the shop page."""
+    # Authentication/authorization checks (if any) would occur here
+    return render_template('shop.html')
+
 @app.route('/', subdomain='fuzzedguitars')
 def guitars_redirect():
     return redirect('https://fuzzedrecords.com/#gear', code=301)

--- a/tests/test_shop_route.py
+++ b/tests/test_shop_route.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import importlib
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+
+
+def test_shop_route_accessible():
+    importlib.reload(app_module)
+    with app_module.app.test_client() as client:
+        resp = client.get('/shop')
+        assert resp.status_code == 200
+        assert b'Custom Guitars' in resp.data


### PR DESCRIPTION
## Summary
- add `/shop` route rendering the shop template (with placeholder for auth checks)
- cover `/shop` with a unit test to ensure it returns 200 and expected content

## Testing
- `pytest -q`
- `curl -i http://127.0.0.1:5000/shop`


------
https://chatgpt.com/codex/tasks/task_e_68bb71083bf0832784965b439cc01102