### PR TITLE
feat: add manual logout for nostr auth

### DIFF
--- a/static/scripts/auth.js
+++ b/static/scripts/auth.js
@@ -116,10 +116,19 @@ export async function authenticateWithNostr() {
   }
 }
 
+// Clear session data when the user explicitly logs out
+export function logout() {
+  sessionStorage.clear();
+  userProfile = null;
+  const menuProfile = document.getElementById('menu-profile');
+  if (menuProfile) {
+    menuProfile.textContent = 'Profile';
+    delete menuProfile.dataset.loggedIn;
+  }
+}
+
 // Initialization: menu buttons
 document.addEventListener('DOMContentLoaded', () => {
-  // Clear session data on reload
-  sessionStorage.removeItem('pubkey');
   document.getElementById('menu-library')
     .addEventListener('click', () => showSection('library'));
   document.getElementById('menu-gear')


### PR DESCRIPTION
## Summary
- avoid clearing Nostr session on page load
- add `logout` helper to clear session data when invoked

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb74408a608327bf29dcec98a2c3d2