### PR TITLE
chore: drop calendar event functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ Set the following environment variables to configure the application:
 - TENANT_ID: Azure AD Tenant ID for discovery JSON endpoint (/.well-known/nostr.json)
 - CLIENT_ID: Azure AD Application (client) ID
 - CLIENT_SECRET: Azure AD Application client secret
-- VALID_PUBKEYS: Comma-separated list of hex pubkeys authorized to publish calendar events
-- IDENTITIES_CACHE: Path to JSON file used when `VALID_PUBKEYS` is unset (default: azure_identities.json)
 - (Optional) LOG_LEVEL: Python log level for application logging (default: DEBUG)
 - (Optional) FLASK_DEBUG: Set to 1 or true for debug mode when running locally
 

--- a/app.py
+++ b/app.py
@@ -98,31 +98,6 @@ SERVER_WALLET_PUBKEY = (
     derive_public_key_hex(WALLET_PRIVKEY_HEX) if WALLET_PRIVKEY_HEX else ""
 )
 
-# Comma-separated list of pubkeys allowed to publish calendar events. If unset,
-# a local cache file specified by IDENTITIES_CACHE (default 'azure_identities.json')
-# is read when present.
-def load_valid_pubkeys():
-    env_val = os.getenv("VALID_PUBKEYS", "").strip()
-    if env_val:
-        return [p.strip() for p in env_val.split(",") if p.strip()]
-    cache_file = os.getenv("IDENTITIES_CACHE", "azure_identities.json")
-    if os.path.exists(cache_file):
-        try:
-            import json
-            with open(cache_file) as f:
-                data = json.load(f)
-            if isinstance(data, list):
-                return [p for p in data if isinstance(p, str)]
-            if isinstance(data, dict):
-                # Expect structure from azure_resources {"names": {name: pubkey}}
-                if "names" in data and isinstance(data["names"], dict):
-                    return [pk for pk in data["names"].values() if isinstance(pk, str)]
-        except Exception as e:
-            logger.warning("Failed to load identities cache %s: %s", cache_file, e)
-    return []
-
-VALID_PUBKEYS = load_valid_pubkeys()
-
 # Active relay list loaded from files/environment
 RELAYS_LOCK = threading.Lock()
 

--- a/nostr_client.py
+++ b/nostr_client.py
@@ -88,7 +88,6 @@ class EventKind:
     WALLET_REQUEST = 23194
     WALLET_RESPONSE = 23195
     WALLET_NOTIFICATION = 23197
-    CALENDAR_EVENT = 31922  # NIP-52 calendar events
 
 @dataclass
 class Event:


### PR DESCRIPTION
## Summary
- remove unused calendar event constant and admin pubkey configuration
- clean up README to drop calendar event references

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2bc0beecc8327bb868557b935bf72