### PR TITLE
Return 502 for token auth failures and prefix invalid_client messages with 'Authentication failed.'

### DIFF
--- a/azure_resources.py
+++ b/azure_resources.py
@@ -15,11 +15,10 @@ def _build_token_error_response(token):
     status_code = 502
     message = "Authentication failed. Check TENANT_ID, CLIENT_ID, and CLIENT_SECRET."
     if error == "invalid_client":
-        status_code = 401
         if "expired" in description.lower():
-            message = "CLIENT_SECRET expired. Update it in Azure and redeploy."
+            message = "Authentication failed. CLIENT_SECRET expired. Update it in Azure and redeploy."
         else:
-            message = "Invalid client credentials. Verify CLIENT_ID and CLIENT_SECRET."
+            message = "Authentication failed. Invalid client credentials. Verify CLIENT_ID and CLIENT_SECRET."
     return {
         "error": message,
         "code": error or "unknown_error",


### PR DESCRIPTION
### Motivation

- Ensure token acquisition failures continue to return a 502 response while keeping error text helpful for `invalid_client` cases.

### Description

- Updated `_build_token_error_response` in `azure_resources.py` to always use a 502 status code for token acquisition failures.
- Preserved the specific `invalid_client` messaging but prefixed both the expired and invalid credential variants with "Authentication failed." for consistency and to match client expectations.

### Testing

- Ran `pytest tests/test_nostrjson_errors.py::test_auth_failure_returns_502` which initially failed against the old behavior and then passed after the change.
- The targeted test `tests/test_nostrjson_errors.py::test_auth_failure_returns_502` passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ec95a7d9883279033ea8dbefaad49)