### PR TITLE
Make Nostr request handlers and NIP-05 decorator async-safe (avoid asyncio.run in ASGI)

### DIFF
--- a/app.py
+++ b/app.py
@@ -208,15 +208,9 @@ async def close_relay_managers():
     for mgr in managers:
         await mgr.close_connections()
 
-_pool_started = False
-
-@app.before_request
-def _startup_pool():
-    global _pool_started
-    if not _pool_started:
-        mgr = asyncio.run(get_relay_manager())
-        asyncio.run(release_relay_manager(mgr))
-        _pool_started = True
+# Relay managers are initialized lazily inside request/worker event loops.
+# Avoid eager warm-up in ``before_request`` because ASGI servers such as
+# Hypercorn already have a running event loop at request time.
 
 import atexit
 

--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -1,4 +1,4 @@
-import json, time, asyncio
+import json, time, asyncio, inspect
 from flask import request, jsonify
 from app import (
     app,
@@ -24,16 +24,19 @@ def require_nip05_verification(required_domain):
 
     def decorator(func):
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        async def wrapper(*args, **kwargs):
             data = request.json or {}
             pubkey = data.get("pubkey")
             if not pubkey:
                 return jsonify({"error": "Missing pubkey"}), 400
-            valid = asyncio.run(fetch_and_validate_profile(pubkey, required_domain))
+            valid = await fetch_and_validate_profile(pubkey, required_domain)
             if not valid:
                 logger.warning(f"NIP-05 failed for {pubkey}")
                 return jsonify({"error": "NIP-05 verification failed"}), 403
-            return func(*args, **kwargs)
+            response = func(*args, **kwargs)
+            if inspect.isawaitable(response):
+                return await response
+            return response
 
         return wrapper
 
@@ -140,16 +143,16 @@ async def fetch_and_validate_profile(pubkey, required_domain):
     return domain == required_domain
 
 @app.route("/fetch-profile", methods=["POST"])
-def _fetch_profile():
-    return asyncio.run(fetch_profile())
+async def _fetch_profile():
+    return await fetch_profile()
 
 @app.route('/validate-profile', methods=['POST'])
-def _validate_profile():
+async def _validate_profile():
     data = request.json or {}
     pubkey = data.get('pubkey')
     if not pubkey:
         return jsonify({"error":"Missing pubkey"}), 400
-    valid = asyncio.run(fetch_and_validate_profile(pubkey, REQUIRED_DOMAIN))
+    valid = await fetch_and_validate_profile(pubkey, REQUIRED_DOMAIN)
     if valid:
         return jsonify({"status":"valid"})
     return jsonify({"error":"Profile validation failed"}), 403
@@ -169,17 +172,15 @@ async def _send_dm_async(to_pubkey: str, content: str, sender_privkey: str):
 
 
 @app.route('/send_dm', methods=['POST'])
-def _send_dm():
+async def _send_dm():
     data = request.json or {}
     required = ['to_pubkey', 'content', 'sender_privkey']
     if not all(k in data for k in required):
         return error_response("Missing DM fields", 400)
 
-    asyncio.run(
-        _send_dm_async(
-            to_pubkey=data['to_pubkey'],
-            content=data['content'],
-            sender_privkey=data['sender_privkey'],
-        )
+    await _send_dm_async(
+        to_pubkey=data['to_pubkey'],
+        content=data['content'],
+        sender_privkey=data['sender_privkey'],
     )
     return jsonify({"message": "DM sent successfully"})

--- a/tests/test_nostr_async_routes.py
+++ b/tests/test_nostr_async_routes.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import inspect
+import asyncio
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from flask import jsonify
+
+import app as app_module
+import nostr_utils
+
+
+def test_nostr_routes_are_async_functions():
+    assert inspect.iscoroutinefunction(nostr_utils._fetch_profile)
+    assert inspect.iscoroutinefunction(nostr_utils._validate_profile)
+    assert inspect.iscoroutinefunction(nostr_utils._send_dm)
+
+
+def test_fetch_profile_route_awaits_async_helper(monkeypatch):
+    async def fake_fetch_profile():
+        return jsonify({"status": "ok"})
+
+    monkeypatch.setattr(nostr_utils, "fetch_profile", fake_fetch_profile)
+
+    with app_module.app.test_request_context("/fetch-profile", method="POST", json={"pubkey": "abc"}):
+        response = asyncio.run(nostr_utils._fetch_profile())
+
+    assert response.get_json() == {"status": "ok"}
+
+
+def test_validate_profile_route_awaits_async_helper(monkeypatch):
+    async def fake_fetch_and_validate_profile(pubkey, required_domain):
+        assert pubkey == "abc"
+        assert required_domain == app_module.REQUIRED_DOMAIN
+        return True
+
+    monkeypatch.setattr(nostr_utils, "fetch_and_validate_profile", fake_fetch_and_validate_profile)
+
+    with app_module.app.test_request_context("/validate-profile", method="POST", json={"pubkey": "abc"}):
+        response = asyncio.run(nostr_utils._validate_profile())
+
+    assert response.get_json() == {"status": "valid"}
+
+
+def test_send_dm_route_awaits_async_helper(monkeypatch):
+    calls = []
+
+    async def fake_send_dm_async(to_pubkey, content, sender_privkey):
+        calls.append((to_pubkey, content, sender_privkey))
+
+    monkeypatch.setattr(nostr_utils, "_send_dm_async", fake_send_dm_async)
+
+    payload = {
+        "to_pubkey": "abc",
+        "content": "hello",
+        "sender_privkey": "priv",
+    }
+    with app_module.app.test_request_context("/send_dm", method="POST", json=payload):
+        response = asyncio.run(nostr_utils._send_dm())
+
+    assert response.get_json() == {"message": "DM sent successfully"}
+    assert calls == [("abc", "hello", "priv")]


### PR DESCRIPTION
### Motivation
- Request handlers and a NIP-05 verification decorator called `asyncio.run(...)` inside request handling, which can conflict with an already-running event loop under ASGI servers like Hypercorn. 
- The goal is to avoid starting new event loops mid-request and ensure async Nostr operations use `await` consistently.

### Description
- Converted the NIP-05 verification decorator in `nostr_utils.py` to use an `async` wrapper and `await fetch_and_validate_profile(...)`, and preserved compatibility with sync/async wrapped views by detecting and awaiting awaitable responses.  
- Changed the Nostr HTTP endpoints in `nostr_utils.py` (`/fetch-profile`, `/validate-profile`, `/send_dm`) to be `async def` handlers that `await` their async helper functions instead of calling `asyncio.run(...)`.  
- Removed the eager relay-manager warm-up from `app.py`'s `before_request` hook to avoid using `asyncio.run(...)` during request processing and documented that relay managers initialize lazily in the active event loop.  
- Added focused regression tests in `tests/test_nostr_async_routes.py` to assert routes are coroutine functions and that each route awaits its async helper correctly.

### Testing
- Ran `pytest -q tests/test_nostr_async_routes.py tests/test_fetch_profile_fail.py tests/test_send_dm_endpoint.py`, and all tests passed (`6 passed`).
- The new tests exercise the async route wrappers and verify that `asyncio.run` is not used during request handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee32241d88327acec76c15cbe401c)