### PR TITLE
Require explicit FRONTEND_ORIGINS for credentialed CORS and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Set the following environment variables to configure the application:
 - CACHE_TIMEOUT: Seconds to cache fetched user profiles (default: 300)
 - REQUIRED_DOMAIN: Domain for NIP-05 profile verification (default: fuzzedrecords.com)
 - MAX_CONTENT_LENGTH: Max request payload size in bytes (default: 1048576)
-- FRONTEND_ORIGINS: Comma-separated list of allowed CORS origins (default: '*')
+- FRONTEND_ORIGINS: Comma-separated list of allowed CORS origins. Required to
+  enable credentialed cross-origin requests; there is no wildcard fallback.
 - AZURE_TABLES_CONNECTION_STRING: Azure connection string for rate-limit storage
 - RATELIMIT_TABLE_NAME: Azure table name for rate-limit counters (default: RateLimit)
 - Rate-limit keys are percent-encoded before being stored in Azure Table Storage.
@@ -141,6 +142,9 @@ Set the following environment variables to configure the application:
    pytest
    ```
    All tests should pass before deployment.
+   If your frontend is hosted on a different origin than the backend, set
+   `FRONTEND_ORIGINS` to an explicit comma-separated allowlist before starting
+   the app. Credentialed CORS is disabled when this variable is unset.
 5. **Run the Application Locally**:
    ```bash
    python app.py

--- a/app.py
+++ b/app.py
@@ -39,13 +39,36 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 # Limit request payload size (e.g. default 1MB)
 app.config['MAX_CONTENT_LENGTH'] = int(os.getenv("MAX_CONTENT_LENGTH", 1048576))
-# Configure CORS origins from environment (comma-separated). Fallback to '*' if not set.
-origins_env = os.getenv("FRONTEND_ORIGINS", "").strip()
-if origins_env:
-    origins = [o.strip() for o in origins_env.split(",") if o.strip()]
-else:
-    origins = ["*"]
-CORS(app, origins=origins, supports_credentials=True)
+
+
+def configure_cors(flask_app):
+    """Configure CORS with an explicit allowlist for credentialed requests.
+
+    Credentialed cross-origin requests are only allowed when
+    ``FRONTEND_ORIGINS`` is set to a comma-separated list of trusted
+    origins. If the variable is unset, cross-origin credentialed requests are
+    disabled entirely instead of falling back to a wildcard.
+    """
+
+    origins_env = os.getenv("FRONTEND_ORIGINS", "").strip()
+    if origins_env:
+        origins = [o.strip() for o in origins_env.split(",") if o.strip()]
+        CORS(flask_app, origins=origins, supports_credentials=True)
+        logger.info(
+            "Credentialed CORS enabled for %d configured origin(s).",
+            len(origins),
+        )
+        return origins, True
+
+    logger.warning(
+        "FRONTEND_ORIGINS is not set; credentialed cross-origin requests are "
+        "disabled. Set FRONTEND_ORIGINS to explicit trusted origins."
+    )
+    CORS(flask_app, origins=[], supports_credentials=False)
+    return [], False
+
+
+ALLOWED_CORS_ORIGINS, CORS_CREDENTIALS_ENABLED = configure_cors(app)
 # Rate limiting (IP-based)
 # Configure Flask-Limiter storage backend via URI and options
 storage_options = {}

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -1,0 +1,42 @@
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+
+
+def test_cors_disabled_when_frontend_origins_unset(monkeypatch):
+    monkeypatch.delenv("FRONTEND_ORIGINS", raising=False)
+    importlib.reload(app_module)
+
+    with app_module.app.test_client() as client:
+        response = client.get("/", headers={"Origin": "https://evil.example"})
+
+    assert app_module.ALLOWED_CORS_ORIGINS == []
+    assert app_module.CORS_CREDENTIALS_ENABLED is False
+    assert response.headers.get("Access-Control-Allow-Origin") is None
+    assert response.headers.get("Access-Control-Allow-Credentials") is None
+
+
+def test_cors_allows_only_configured_origins(monkeypatch):
+    monkeypatch.setenv(
+        "FRONTEND_ORIGINS",
+        "https://app.example.com, https://admin.example.com",
+    )
+    importlib.reload(app_module)
+
+    with app_module.app.test_client() as client:
+        allowed = client.get("/", headers={"Origin": "https://app.example.com"})
+        blocked = client.get("/", headers={"Origin": "https://evil.example"})
+
+    assert app_module.ALLOWED_CORS_ORIGINS == [
+        "https://app.example.com",
+        "https://admin.example.com",
+    ]
+    assert app_module.CORS_CREDENTIALS_ENABLED is True
+    assert allowed.headers.get("Access-Control-Allow-Origin") == "https://app.example.com"
+    assert allowed.headers.get("Access-Control-Allow-Credentials") == "true"
+    assert blocked.headers.get("Access-Control-Allow-Origin") is None
+    assert blocked.headers.get("Access-Control-Allow-Credentials") is None


### PR DESCRIPTION
### Motivation

- Prevent accidental credentialed cross-origin requests by removing the implicit wildcard fallback for CORS and requiring explicit allowed origins. 
- Make CORS configuration clearer for deployers and document the runtime requirement in the README.

### Description

- Replace inline CORS setup in `app.py` with a new `configure_cors` function that enables credentialed CORS only when `FRONTEND_ORIGINS` is set to an explicit comma-separated allowlist and otherwise disables credentialed cross-origin requests. 
- Expose `ALLOWED_CORS_ORIGINS` and `CORS_CREDENTIALS_ENABLED` from `app.py` and emit informative `logger` messages about the configured state. 
- Update `README.md` to document that `FRONTEND_ORIGINS` is required to enable credentialed cross-origin requests and to advise setting it when frontend and backend are hosted on different origins. 
- Add unit tests in `tests/test_cors_config.py` that verify disabled and enabled CORS behaviors depending on `FRONTEND_ORIGINS`.

### Testing

- Ran `pytest`, which executed the new `tests/test_cors_config.py` alongside the suite. All tests passed. 
- The CORS tests validate both the unset (`FRONTEND_ORIGINS` absent) and configured allowlist scenarios and confirmed header behavior as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee4ec9bf88327a0f06d52b9847209)