### PR TITLE
Harden global and Azure-backed rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Set the following environment variables to configure the application:
   enable credentialed cross-origin requests; there is no wildcard fallback.
 - AZURE_TABLES_CONNECTION_STRING: Azure connection string for rate-limit storage
 - RATELIMIT_TABLE_NAME: Azure table name for rate-limit counters (default: RateLimit)
-- Rate-limit keys are percent-encoded before being stored in Azure Table Storage.
+- RATELIMIT_DEFAULT: Semicolon-separated default per-route rate limits applied to routes without their own decorator (default: `60 per minute`)
+- RATELIMIT_APPLICATION: Optional semicolon-separated app-wide shared rate limits that apply across all routes for the same client key
+- RATELIMIT_AZURE_RETRIES: Number of optimistic-concurrency retries for Azure Table Storage counter updates (default: 5)
+- Rate-limit keys are percent-encoded before being stored in Azure Table Storage, and counter writes use ETag-based retries to avoid lost updates under concurrent traffic.
 - RATELIMIT_STORAGE_URI: Alternate limiter storage URI (default: memory://)
 - WAVLAKE_API_BASE: Base URL for Wavlake API (default: https://wavlake.com/api/v1)
 - HTTP_TIMEOUT: Timeout in seconds for external API requests such as Wavlake and Azure Graph (default: 5)

--- a/app.py
+++ b/app.py
@@ -69,6 +69,22 @@ def configure_cors(flask_app):
 
 
 ALLOWED_CORS_ORIGINS, CORS_CREDENTIALS_ENABLED = configure_cors(app)
+
+
+def parse_rate_limit_config(env_var: str, default: str | None = None) -> list[str] | None:
+    """Parse a semicolon-delimited rate-limit config from the environment."""
+
+    raw_value = os.getenv(env_var, "").strip()
+    if raw_value:
+        limits = [item.strip() for item in raw_value.split(";") if item.strip()]
+        if limits:
+            return limits
+    return [default] if default else None
+
+
+DEFAULT_RATE_LIMITS = parse_rate_limit_config("RATELIMIT_DEFAULT", "60 per minute")
+APPLICATION_RATE_LIMITS = parse_rate_limit_config("RATELIMIT_APPLICATION")
+
 # Rate limiting (IP-based)
 # Configure Flask-Limiter storage backend via URI and options
 storage_options = {}
@@ -85,6 +101,8 @@ else:
 limiter = Limiter(
     key_func=get_remote_address,
     app=app,
+    default_limits=DEFAULT_RATE_LIMITS,
+    application_limits=APPLICATION_RATE_LIMITS,
     storage_uri=storage_uri,
     storage_options=storage_options,
 )
@@ -177,6 +195,7 @@ def error_response(message, status_code):
 
 # Relay manager pool
 _manager_pool = []
+_pool_started = False
 _pool_lock = asyncio.Lock()
 
 async def get_relay_manager():

--- a/azure_storage_limiter.py
+++ b/azure_storage_limiter.py
@@ -1,13 +1,20 @@
 import os
 import time
-from limits.storage import Storage
-from azure.data.tables import TableServiceClient, UpdateMode
-from urllib.parse import quote
-from azure.core.exceptions import ResourceExistsError, AzureError
 from typing import Optional
-"""
-Azure Table Storage backend for Flask-Limiter.
-"""
+from urllib.parse import quote
+
+from azure.core import MatchConditions
+from azure.core.exceptions import (
+    AzureError,
+    ResourceExistsError,
+    ResourceModifiedError,
+    ResourceNotFoundError,
+)
+from azure.data.tables import TableServiceClient, UpdateMode
+from limits.storage import Storage
+
+"""Azure Table Storage backend for Flask-Limiter."""
+
 
 class AzureTableStorage(Storage):
     # Register this storage backend under the "azuretables" scheme
@@ -16,7 +23,7 @@ class AzureTableStorage(Storage):
     A Flask-Limiter storage backend using Azure Table Storage.
     Registered under the 'azuretables://' scheme.
     """
-    # Underlying TableServiceClient storage
+
     def __init__(
         self,
         uri: Optional[str] = None,
@@ -30,6 +37,7 @@ class AzureTableStorage(Storage):
         if not conn_str:
             raise ValueError("AZURE_TABLES_CONNECTION_STRING must be set to use AzureTableStorage")
         table_name = options.get("table_name") or os.getenv("RATELIMIT_TABLE_NAME", "RateLimit")
+        self.max_retries = int(options.get("max_retries") or os.getenv("RATELIMIT_AZURE_RETRIES", "5"))
         # Initialize table client
         service = TableServiceClient.from_connection_string(conn_str)
         self.client = service.get_table_client(table_name)
@@ -57,6 +65,15 @@ class AzureTableStorage(Storage):
             partition = sanitized
         return partition, sanitized
 
+    @staticmethod
+    def _extract_etag(entity) -> Optional[str]:
+        metadata = getattr(entity, "metadata", None)
+        if metadata:
+            return metadata.get("etag")
+        if isinstance(entity, dict):
+            return entity.get("etag")
+        return None
+
     def incr(
         self,
         key: str,
@@ -64,14 +81,33 @@ class AzureTableStorage(Storage):
         elastic_expiry: bool = False,
         amount: int = 1,
     ) -> int:
-        """Increment the count for ``key`` by ``amount`` and set expiry."""
-        now = int(time.time())
+        """Increment the count for ``key`` by ``amount`` and set expiry.
+
+        Azure Table Storage does not support server-side atomic increments, so we
+        use optimistic concurrency with entity ETags to avoid lost updates under
+        concurrent traffic.
+        """
         partition_key, row_key = self._get_partition_and_row(key)
-        try:
-            entity = self.client.get_entity(partition_key, row_key)
+
+        for _ in range(self.max_retries):
+            now = int(time.time())
+            try:
+                entity = self.client.get_entity(partition_key, row_key)
+            except ResourceNotFoundError:
+                entity = {
+                    "PartitionKey": partition_key,
+                    "RowKey": row_key,
+                    "count": amount,
+                    "expire_at": now + expiry,
+                }
+                try:
+                    self.client.create_entity(entity)
+                    return amount
+                except ResourceExistsError:
+                    continue
+
             count = entity.get("count", 0)
             expire_at = entity.get("expire_at", 0)
-            # Reset or increment
             if now > expire_at:
                 count = amount
                 expire_at = now + expiry
@@ -79,22 +115,22 @@ class AzureTableStorage(Storage):
                 count += amount
                 if elastic_expiry:
                     expire_at = now + expiry
+
             entity["count"] = count
             entity["expire_at"] = expire_at
-            # azure-data-tables >=12.4 expects UpdateMode enums instead of strings
-            self.client.update_entity(entity, mode=UpdateMode.MERGE)
-        except AzureError:
-            # Entity not found or any error: create new entity
-            count = amount
-            expire_at = now + expiry
-            entity = {
-                "PartitionKey": partition_key,
-                "RowKey": row_key,
-                "count": count,
-                "expire_at": expire_at
-            }
-            self.client.create_entity(entity)
-        return count
+
+            try:
+                self.client.update_entity(
+                    entity,
+                    mode=UpdateMode.MERGE,
+                    etag=self._extract_etag(entity),
+                    match_condition=MatchConditions.IfNotModified,
+                )
+                return count
+            except (ResourceModifiedError, ResourceNotFoundError):
+                continue
+
+        raise RuntimeError(f"Failed to increment rate-limit key after {self.max_retries} retries: {key}")
 
     def get(self, key: str) -> int:
         """Return the current count for a key, or 0 if non-existent/expired."""
@@ -106,7 +142,7 @@ class AzureTableStorage(Storage):
             if now > expire_at:
                 return 0
             return entity.get("count", 0)
-        except AzureError:
+        except ResourceNotFoundError:
             return 0
 
     def clear(self, key: str) -> None:
@@ -114,7 +150,7 @@ class AzureTableStorage(Storage):
         partition_key, row_key = self._get_partition_and_row(key)
         try:
             self.client.delete_entity(partition_key, row_key)
-        except AzureError:
+        except ResourceNotFoundError:
             pass
 
     # Exceptions to catch during storage operations
@@ -127,6 +163,7 @@ class AzureTableStorage(Storage):
     def get_expiry(self, window) -> int:
         """Convert a window (int or timedelta) to seconds."""
         import datetime
+
         if isinstance(window, datetime.timedelta):
             return int(window.total_seconds())
         try:

--- a/tests/test_app_rate_limit_config.py
+++ b/tests/test_app_rate_limit_config.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app
+
+
+def test_parse_rate_limit_config_defaults(monkeypatch):
+    monkeypatch.delenv("RATELIMIT_DEFAULT", raising=False)
+
+    assert app.parse_rate_limit_config("RATELIMIT_DEFAULT", "60 per minute") == ["60 per minute"]
+
+
+def test_parse_rate_limit_config_supports_semicolon_lists(monkeypatch):
+    monkeypatch.setenv("RATELIMIT_APPLICATION", "100 per minute; 1000 per hour")
+
+    assert app.parse_rate_limit_config("RATELIMIT_APPLICATION") == [
+        "100 per minute",
+        "1000 per hour",
+    ]

--- a/tests/test_azure_storage_limiter.py
+++ b/tests/test_azure_storage_limiter.py
@@ -1,30 +1,71 @@
 import os
 import sys
 
+from azure.core import MatchConditions
+from azure.core.exceptions import (
+    ResourceExistsError,
+    ResourceModifiedError,
+    ResourceNotFoundError,
+)
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import azure_storage_limiter
 
 
+class DummyEntity(dict):
+    def __init__(self, *args, etag=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.metadata = {"etag": etag}
+
+
 class DummyTableClient:
     def __init__(self):
         self.entities = {}
+        self.conflict_once = False
+        self.create_conflict_once = False
 
     def create_table(self):
         pass
 
+    def _next_etag(self, previous=None):
+        if previous and previous.startswith("v") and previous[1:].isdigit():
+            return f"v{int(previous[1:]) + 1}"
+        return "v1"
+
     def get_entity(self, pk, rk):
         if (pk, rk) not in self.entities:
-            from azure.core.exceptions import AzureError
+            raise ResourceNotFoundError("not found")
+        entity = self.entities[(pk, rk)]
+        return DummyEntity(entity, etag=entity["etag"])
 
-            raise AzureError("not found")
-        return dict(self.entities[(pk, rk)])
+    def update_entity(self, entity, mode="MERGE", *, etag=None, match_condition=None):
+        key = (entity["PartitionKey"], entity["RowKey"])
+        if key not in self.entities:
+            raise ResourceNotFoundError("not found")
 
-    def update_entity(self, entity, mode="MERGE"):
-        self.entities[(entity["PartitionKey"], entity["RowKey"])] = entity
+        stored = self.entities[key]
+        if self.conflict_once:
+            stored["count"] += 1
+            stored["etag"] = self._next_etag(stored["etag"])
+            self.conflict_once = False
+
+        if match_condition == MatchConditions.IfNotModified and etag != stored["etag"]:
+            raise ResourceModifiedError("etag mismatch")
+
+        new_entity = dict(entity)
+        new_entity["etag"] = self._next_etag(stored["etag"])
+        self.entities[key] = new_entity
 
     def create_entity(self, entity):
-        self.entities[(entity["PartitionKey"], entity["RowKey"])] = entity
+        key = (entity["PartitionKey"], entity["RowKey"])
+        if self.create_conflict_once:
+            self.entities[key] = {**entity, "count": 1, "etag": "v1"}
+            self.create_conflict_once = False
+            raise ResourceExistsError("already exists")
+        if key in self.entities:
+            raise ResourceExistsError("already exists")
+        self.entities[key] = {**entity, "etag": "v1"}
 
     def delete_entity(self, pk, rk):
         self.entities.pop((pk, rk), None)
@@ -42,9 +83,13 @@ class DummyService:
         return self.client
 
 
-def test_key_sanitization(monkeypatch):
+def build_limiter(monkeypatch):
     monkeypatch.setattr(azure_storage_limiter, "TableServiceClient", DummyService)
-    limiter = azure_storage_limiter.AzureTableStorage(connection_string="conn")
+    return azure_storage_limiter.AzureTableStorage(connection_string="conn")
+
+
+def test_key_sanitization(monkeypatch):
+    limiter = build_limiter(monkeypatch)
 
     key = "LIMITER/169.254.130.1/generic_endpoint/10/1/minute"
 
@@ -59,3 +104,23 @@ def test_key_sanitization(monkeypatch):
     limiter.clear(key)
     assert limiter.get(key) == 0
 
+
+def test_incr_retries_on_optimistic_concurrency_conflict(monkeypatch):
+    limiter = build_limiter(monkeypatch)
+    key = "LIMITER/127.0.0.1/conflict"
+
+    assert limiter.incr(key, expiry=60) == 1
+    limiter.client.conflict_once = True
+
+    assert limiter.incr(key, expiry=60) == 3
+    assert limiter.get(key) == 3
+
+
+def test_incr_retries_when_create_races(monkeypatch):
+    limiter = build_limiter(monkeypatch)
+    key = "LIMITER/127.0.0.1/create-race"
+
+    limiter.client.create_conflict_once = True
+
+    assert limiter.incr(key, expiry=60) == 2
+    assert limiter.get(key) == 2


### PR DESCRIPTION
### Motivation
- Ensure a global/default throttle is applied so routes without per-route decorators are not left unthrottled.
- Prevent lost or undercounted Azure-backed rate-limit increments under concurrent traffic by avoiding non-atomic read-modify-write updates.

### Description
- Add `parse_rate_limit_config` and environment-driven `DEFAULT_RATE_LIMITS` and `APPLICATION_RATE_LIMITS` in `app.py`, and wire them into the `Limiter` via `default_limits` and `application_limits` so routes inherit a baseline throttle (`RATELIMIT_DEFAULT` / `RATELIMIT_APPLICATION`).
- Rework `azure_storage_limiter.py` to use ETag-based optimistic concurrency with bounded retries (`RATELIMIT_AZURE_RETRIES`) and helper `_extract_etag`, handling create/update races and using `MatchConditions.IfNotModified` when calling `update_entity`.
- Update `README.md` to document `RATELIMIT_DEFAULT`, `RATELIMIT_APPLICATION`, and `RATELIMIT_AZURE_RETRIES`, and clarify Azure-backed counter behavior.
- Add and update tests to cover config parsing and Azure Table Storage concurrency scenarios, and restore a small relay-pool sentinel to keep existing tests compatible.

### Testing
- Ran `python -m py_compile app.py azure_storage_limiter.py tests/test_azure_storage_limiter.py tests/test_app_rate_limit_config.py` which succeeded without syntax errors. 
- Ran `pytest -q tests/test_azure_storage_limiter.py tests/test_app_rate_limit_config.py` and observed the new regression tests pass. 
- Ran full test suite with `pytest -q` and confirmed all tests passed (`38 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee7712cf48327a5b7fce114da8d23)