### PR TITLE
Offload Wavlake library build from request loop

### DIFF
--- a/tests/test_tracks_endpoint.py
+++ b/tests/test_tracks_endpoint.py
@@ -29,3 +29,37 @@ def test_tracks_first_request_builds_library(monkeypatch):
         assert resp.status_code == 200
         assert resp.get_json() == {"tracks": sample}
 
+
+
+def test_tracks_first_request_offloads_library_build(monkeypatch):
+    import app as app_module
+    import wavlake_utils
+    importlib.reload(app_module)
+    importlib.reload(wavlake_utils)
+
+    sample = [{
+        "artist": "A",
+        "album": "B",
+        "title": "T",
+        "media_url": "url",
+        "track_id": "1",
+    }]
+
+    wavlake_utils._track_cache = {"library": None, "ts": 0}
+
+    def fake_build():
+        raise AssertionError("build_music_library should be called via asyncio.to_thread")
+
+    async def fake_to_thread(func, *args, **kwargs):
+        assert func is fake_build
+        assert args == ()
+        assert kwargs == {}
+        return sample
+
+    monkeypatch.setattr(wavlake_utils, "build_music_library", fake_build)
+    monkeypatch.setattr(wavlake_utils.asyncio, "to_thread", fake_to_thread)
+
+    with app_module.app.test_client() as client:
+        resp = client.get("/tracks")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"tracks": sample}

--- a/wavlake_utils.py
+++ b/wavlake_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import time
@@ -129,17 +130,17 @@ def register_wavlake_routes(app, base_url=None, search_term=None, error_handler=
     SEARCH_TERM = search_term or os.getenv("SEARCH_TERM", SEARCH_TERM)
     _error_handler = error_handler or _default_error_handler
     @app.route('/tracks', methods=['GET'])
-    def get_tracks():
+    async def get_tracks():
         """Return the music library, building it on-demand if missing."""
         global _updating
         now = time.time()
         cached = _track_cache.get('library')
 
         if cached is None:
-            # No library yet - build synchronously so the first request has data
-            logger.info("Cache empty, building music library synchronously")
+            # No library yet - build off the event loop so the first request still gets data
+            logger.info("Cache empty, building music library in a worker thread")
             try:
-                library = build_music_library()
+                library = await asyncio.to_thread(build_music_library)
             except Exception as e:
                 logger.error(f"Failed to build music library: {e}")
                 return _error_handler("Failed to load library", 500)


### PR DESCRIPTION
### Motivation
- The Wavlake fetch path used `requests` inside the `/tracks` request handler which can block the event loop and reduce throughput for the async Flask app.  
- The intent is to avoid blocking the main request loop on a cache miss while still returning data on the first request by running the blocking work off the event loop.

### Description
- Convert the `/tracks` handler in `wavlake_utils.py` to an `async def` route and add `import asyncio` to the module.  
- Offload the initial `build_music_library()` call on cache miss with `await asyncio.to_thread(build_music_library)` so Wavlake HTTP fetches no longer run inline on the event loop.  
- Update the log message to reflect the worker-thread behavior and keep the existing background refresh logic unchanged.  
- Add a regression test `test_tracks_first_request_offloads_library_build` in `tests/test_tracks_endpoint.py` that monkeypatches `build_music_library` and `asyncio.to_thread` to assert the build is dispatched through `asyncio.to_thread`.

### Testing
- Ran the targeted test suite with `pytest -q tests/test_build_music_library.py tests/test_tracks_endpoint.py`.  
- All tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beea9129908327b52c014b9bdec7bf)