### PR TITLE
Prevent XSS in track rendering by using safe DOM construction

### DIFF
--- a/static/scripts/tracks.js
+++ b/static/scripts/tracks.js
@@ -10,10 +10,18 @@ export async function fetchTracks() {
       data.tracks.forEach(track => {
         const trackElement = document.createElement('div');
         trackElement.classList.add('song-item');
-        trackElement.innerHTML = `
-          <h3>${track.title} by ${track.artist}</h3>
-          <iframe src="https://embed.wavlake.com/track/${track.track_id}" width="100%" height="380" frameborder="0"></iframe>
-        `;
+
+        const heading = document.createElement('h3');
+        heading.textContent = `${track.title} by ${track.artist}`;
+
+        const iframe = document.createElement('iframe');
+        iframe.src = `https://embed.wavlake.com/track/${encodeURIComponent(track.track_id)}`;
+        iframe.width = '100%';
+        iframe.height = '380';
+        iframe.frameBorder = '0';
+
+        trackElement.appendChild(heading);
+        trackElement.appendChild(iframe);
         songsSection.appendChild(trackElement);
       });
     } else {


### PR DESCRIPTION
### Motivation
- Close an XSS vector where `title` and `artist` were inserted via `innerHTML` by ensuring API-provided strings are treated as text and not parsed as HTML.

### Description
- Replace the `innerHTML`-based rendering in `static/scripts/tracks.js` with explicit DOM creation, render `title` and `artist` via `textContent`, and `encodeURIComponent` the `track_id` when building the Wavlake iframe `src`.

### Testing
- Ran `python -m py_compile $(find . -name '*.py' -not -path './.venv/*' -not -path './node_modules/*' 2>/dev/null)` which succeeded, and performed a manual diff review of `static/scripts/tracks.js` to verify the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beeb8f7af083279962880234d6fa13)