### PR TITLE
Reduce Nostr relay polling wakeups

### DIFF
--- a/nostr_utils.py
+++ b/nostr_utils.py
@@ -19,6 +19,16 @@ from nostr_client import (
     EncryptedDirectMessage,
 )
 
+POLL_INITIAL_INTERVAL = 0.05
+POLL_MAX_INTERVAL = 0.5
+
+
+def _next_poll_interval(current_interval):
+    """Return the next bounded poll interval for relay message polling."""
+    if current_interval <= 0:
+        return POLL_INITIAL_INTERVAL
+    return min(current_interval * 2, POLL_MAX_INTERVAL)
+
 def require_nip05_verification(required_domain):
     from functools import wraps
 
@@ -72,6 +82,7 @@ async def fetch_profile():
         logger.debug("Awaiting profile event for pubkey %s", pubkey_hex)
 
         profile_data = {}
+        poll_interval = POLL_INITIAL_INTERVAL
         start = time.time()
         while time.time() - start < PROFILE_FETCH_TIMEOUT:
             if mgr.message_pool.has_events():
@@ -90,12 +101,20 @@ async def fetch_profile():
                             profile_data["nprofile"] = nprof
                         logger.info("Profile data parsed for pubkey %s: %s", pubkey_hex, content)
                     break
+                poll_interval = POLL_INITIAL_INTERVAL
+                continue
             if mgr.message_pool.has_eose_notices():
                 notice = mgr.message_pool.get_eose_notice()
                 if notice.subscription_id == sub_id:
+                    poll_interval = POLL_INITIAL_INTERVAL
                     # Ignore EOSE and continue waiting
                     continue
-            await asyncio.sleep(0.05)
+            elapsed = time.time() - start
+            remaining = PROFILE_FETCH_TIMEOUT - elapsed
+            if remaining <= 0:
+                break
+            await asyncio.sleep(min(poll_interval, remaining))
+            poll_interval = _next_poll_interval(poll_interval)
     if profile_data:
         if nprof and "nprofile" not in profile_data:
             profile_data["nprofile"] = nprof

--- a/tests/test_nostr_async_routes.py
+++ b/tests/test_nostr_async_routes.py
@@ -3,6 +3,8 @@ import sys
 import inspect
 import asyncio
 
+import pytest
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from flask import jsonify
@@ -61,3 +63,54 @@ def test_send_dm_route_awaits_async_helper(monkeypatch):
 
     assert response.get_json() == {"message": "DM sent successfully"}
     assert calls == [("abc", "hello", "priv")]
+
+
+def test_fetch_profile_uses_exponential_backoff(monkeypatch):
+    sleep_calls = []
+
+    class EmptyPool:
+        def has_events(self):
+            return False
+
+        def has_eose_notices(self):
+            return False
+
+    class DummyMgr:
+        connection_statuses = {"r1": True}
+        message_pool = EmptyPool()
+
+        async def add_subscription_on_all_relays(self, *args, **kwargs):
+            return None
+
+    class TimeController:
+        def __init__(self):
+            self.current = 0.0
+
+        def time(self):
+            return self.current
+
+    time_controller = TimeController()
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+        time_controller.current += delay
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def dummy_relay_manager():
+        yield DummyMgr()
+
+    monkeypatch.setattr(nostr_utils, "relay_manager", dummy_relay_manager)
+    monkeypatch.setattr(nostr_utils, "get_cached_item", lambda pubkey: None)
+    monkeypatch.setattr(nostr_utils, "nprofile_encode", lambda pubkey, relays: None)
+    monkeypatch.setattr(nostr_utils.time, "time", time_controller.time)
+    monkeypatch.setattr(nostr_utils.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(nostr_utils, "PROFILE_FETCH_TIMEOUT", 0.4)
+
+    with app_module.app.test_request_context("/fetch-profile", method="POST", json={"pubkey": "abc"}):
+        response, status_code = asyncio.run(nostr_utils.fetch_profile())
+
+    assert status_code == 404
+    assert response.get_json() == {"error": "Profile not found"}
+    assert sleep_calls == pytest.approx([0.05, 0.1, 0.2, 0.05])


### PR DESCRIPTION
### Motivation
- Reduce CPU wake-ups from a tight fixed sleep when polling Nostr relays while waiting for profile events.
- Avoid overshooting the `PROFILE_FETCH_TIMEOUT` by capping sleeps to the remaining time window.

### Description
- Add bounded polling parameters `POLL_INITIAL_INTERVAL` and `POLL_MAX_INTERVAL` and a `_next_poll_interval()` helper to compute exponential backoff.
- Replace the fixed `asyncio.sleep(0.05)` in `fetch_profile()` with a `poll_interval` that doubles up to the cap, resets when activity is detected, and is clamped to the remaining timeout before sleeping.
- Reset the interval on received events or EOSE notices so the loop becomes responsive again when relays are active.
- Add a focused test `test_fetch_profile_uses_exponential_backoff` (and import `pytest`) that stubs `time` and `asyncio.sleep` to assert the expected backoff cadence and updated the assertion to use `pytest.approx` for float comparisons.

### Testing
- Ran `pytest -q tests/test_nostr_async_routes.py tests/test_fetch_profile_fail.py tests/test_send_dm_endpoint.py` and all tests passed (`7 passed`).
- The new backoff test `test_fetch_profile_uses_exponential_backoff` passed and verifies the sleep cadence when no relay events arrive.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beec4fb0b483278a77fd1699231c99)