### PR TITLE
Update site stylesheet responsiveness

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -8,17 +8,15 @@ body {
 
 .logo-container {
     max-width: 500px;
-    width: 80%;
-    height: 220px;
+    width: 90%;
     margin: 20px auto;
-    overflow: hidden;
 }
 
 .logo {
     display: block;
     width: 100%;
-    height: 100%;
-    object-fit: cover;
+    height: auto;
+    object-fit: contain;
 }
 
 .menu {
@@ -300,14 +298,13 @@ footer {
 @media (min-width: 768px) {
     .logo-container {
         max-width: 350px;
-        height: 150px;
     }
 
     .gear-container {
         max-width: 350px;
     }
+
     .gear-gallery {
         max-width: 350px;
     }
 }
-


### PR DESCRIPTION
### Motivation
- Prevent the site logo from being cropped by restoring responsive sizing and avoiding fixed-height container rules in the stylesheet.

### Description
- Updated `static/style.css` to set `.logo-container` to `width: 90%` and removed the fixed `height` and `overflow: hidden` that caused cropping.
- Changed `.logo` to use `height: auto` and `object-fit: contain` so the full logo scales proportionally.
- Removed the desktop media-query override that set a fixed logo height so the logo behaves consistently across breakpoints.
- All edits were applied in `static/style.css` to restore the intended responsive behavior.

### Testing
- Ran the test suite with `pytest -q` and all tests passed: `40 passed in 9.21s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef053d45483278cbd401105173eb0)