### PR TITLE
Simplify Fuzzed Records public music flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Fuzzed Records is a simple independent music hub for noisy, guitar-driven bands.
 
 ## Features
 
-- **Music Hub**: Stream featured Fuzzed Records tracks using SoundCloud and Wavlake where appropriate.
+- **Music Hub**: Stream featured Fuzzed Records tracks through a simple SoundCloud-first homepage experience.
 - **Direct Support**: Link listeners to Wavlake tracks for boosts and direct artist support.
 - **Band Submissions**: Provide a simple path for future bands to contact or submit music.
 - **Nostr / Lightning**: Keep advanced identity and payment features available where useful, but not as the primary public journey.
@@ -26,7 +26,7 @@ Fuzzed Records is a simple independent music hub for noisy, guitar-driven bands.
 - **Efficient Data Caching**: Utilizes caching for optimizing data retrieval performance.
 - **Rate Limiting**: Protects API endpoints using Flask-Limiter with optional Azure Table Storage backend (ASGI-compatible).
 - **CORS Configuration**: Allowed origins can be customized via environment variable (Flask-CORS works under Hypercorn).
-- **Section Links**: Use URL hashes like `/#listen`, `/#bands`, `/#submit`, `/#support`, and `/#about` to open public sections directly.
+- **Section Links**: Use URL hashes like `/#listen`, `/#bands`, `/#submit`, `/#support`, and `/#about` to open public sections directly. Legacy `/fuzzedguitars` traffic redirects to the homepage.
 
 ---
 

--- a/static/scripts/auth.js
+++ b/static/scripts/auth.js
@@ -1,6 +1,6 @@
 // auth.js
 // Handles navigation and Nostr authentication (NIP-07) logic
-import { showSection, getPublicSections } from './utils.js';
+import { highlightSection, getPublicSections } from './utils.js';
 
 // Global profile state
 let userProfile = null;
@@ -129,19 +129,16 @@ export function logout() {
 
 // Initialization: menu buttons
 document.addEventListener('DOMContentLoaded', () => {
-  getPublicSections().forEach(section => {
-    const navLink = document.getElementById(`menu-${section}`);
-    if (navLink) {
-      navLink.addEventListener('click', event => {
-        event.preventDefault();
-        history.pushState(null, '', `#${section}`);
-        showSection(section);
-      });
-    }
-  });
+  const setActiveFromHash = () => {
+    const hash = window.location.hash.replace('#', '');
+    highlightSection(getPublicSections().includes(hash) ? hash : 'listen');
+  };
+
+  setActiveFromHash();
+  window.addEventListener('hashchange', setActiveFromHash);
 
   const menuProfile = document.getElementById('menu-profile');
-  menuProfile.addEventListener('click', async () => {
+  menuProfile?.addEventListener('click', async () => {
     if (!menuProfile.dataset.loggedIn) {
       menuProfile.textContent = 'Signing in...';
       await authenticateWithNostr();
@@ -152,19 +149,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (advanced) {
       advanced.open = true;
       document.getElementById('profile-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  });
-
-  // Allow linking directly to public sections via URL hash (e.g., /#listen).
-  const hash = window.location.hash.replace('#', '');
-  if (getPublicSections().includes(hash)) {
-    showSection(hash);
-  }
-
-  window.addEventListener('hashchange', () => {
-    const nextHash = window.location.hash.replace('#', '');
-    if (getPublicSections().includes(nextHash)) {
-      showSection(nextHash);
     }
   });
 });

--- a/static/scripts/tracks.js
+++ b/static/scripts/tracks.js
@@ -1,76 +1,115 @@
 // tracks.js
-// Handles fetching and rendering the music library
-const SOUNDCLOUD_URL = 'https://soundcloud.com/fuzzedrecords';
+// Handles fetching and rendering the Wavlake direct-support library.
+
+function firstPresent(...values) {
+  return values.find(value => typeof value === 'string' && value.trim())?.trim() || null;
+}
 
 function trackSupportUrl(track) {
-  return track.url || track.link || track.wavlake_url || track.wavlakeUrl || (track.track_id ? `https://wavlake.com/track/${encodeURIComponent(track.track_id)}` : null);
+  return firstPresent(
+    track.url,
+    track.link,
+    track.wavlake_url,
+    track.wavlakeUrl,
+    track.media_url,
+    track.mediaUrl,
+  ) || (track.track_id ? `https://wavlake.com/track/${encodeURIComponent(track.track_id)}` : null);
+}
+
+function trackTitle(track) {
+  return firstPresent(track.title, track.name, track.track_title, track.trackTitle) || 'Untitled Wavlake track';
+}
+
+function artistName(track) {
+  return firstPresent(track.artist, track.artist_name, track.artistName, track.creator, track.author) || 'Artist not listed';
+}
+
+function albumName(track) {
+  return firstPresent(track.album, track.album_title, track.albumTitle, track.release, track.collection) || 'Album not listed';
+}
+
+function artworkUrl(track) {
+  return firstPresent(track.artwork, track.artwork_url, track.artworkUrl, track.album_art, track.albumArt, track.image, track.image_url);
+}
+
+function renderTrack(track) {
+  const trackElement = document.createElement('article');
+  trackElement.classList.add('song-item');
+
+  const artwork = artworkUrl(track);
+  if (artwork) {
+    const image = document.createElement('img');
+    image.classList.add('track-artwork');
+    image.src = artwork;
+    image.alt = `${trackTitle(track)} artwork`;
+    image.loading = 'lazy';
+    trackElement.appendChild(image);
+  }
+
+  const heading = document.createElement('h3');
+  heading.textContent = trackTitle(track);
+  trackElement.appendChild(heading);
+
+  const meta = document.createElement('p');
+  meta.classList.add('track-meta');
+  meta.textContent = `${artistName(track)} · ${albumName(track)}`;
+  trackElement.appendChild(meta);
+
+  if (track.track_id) {
+    const iframe = document.createElement('iframe');
+    iframe.title = `${trackTitle(track)} on Wavlake`;
+    iframe.src = `https://embed.wavlake.com/track/${encodeURIComponent(track.track_id)}`;
+    iframe.width = '100%';
+    iframe.height = '380';
+    iframe.frameBorder = '0';
+    iframe.loading = 'lazy';
+    trackElement.appendChild(iframe);
+  } else {
+    const playerFallback = document.createElement('p');
+    playerFallback.classList.add('fallback-copy');
+    playerFallback.textContent = 'Embedded Wavlake player is not available for this track yet.';
+    trackElement.appendChild(playerFallback);
+  }
+
+  const supportUrl = trackSupportUrl(track);
+  if (supportUrl) {
+    const links = document.createElement('div');
+    links.classList.add('track-links');
+
+    const wavlakeLink = document.createElement('a');
+    wavlakeLink.href = supportUrl;
+    wavlakeLink.target = '_blank';
+    wavlakeLink.rel = 'noopener noreferrer';
+    wavlakeLink.textContent = 'Support on Wavlake';
+    links.appendChild(wavlakeLink);
+    trackElement.appendChild(links);
+  }
+
+  return trackElement;
 }
 
 export async function fetchTracks() {
   const songsSection = document.getElementById('songs-section');
   if (!songsSection) return;
 
+  songsSection.innerHTML = '<p class="fallback-copy">Loading Wavlake support links…</p>';
+
   try {
     const response = await fetch('/tracks');
     if (!response.ok) throw new Error(`Tracks request failed: ${response.status}`);
 
     const data = await response.json();
+    const tracks = Array.isArray(data.tracks) ? data.tracks : [];
     songsSection.innerHTML = '';
-    if (data.tracks && data.tracks.length > 0) {
-      data.tracks.forEach(track => {
-        const trackElement = document.createElement('article');
-        trackElement.classList.add('song-item');
 
-        const heading = document.createElement('h3');
-        heading.textContent = track.title || 'Untitled track';
-
-        const artist = document.createElement('p');
-        artist.classList.add('track-artist');
-        artist.textContent = track.artist ? `Artist: ${track.artist}` : 'Artist: Fuzzed Records';
-
-        trackElement.appendChild(heading);
-        trackElement.appendChild(artist);
-
-        if (track.track_id) {
-          const iframe = document.createElement('iframe');
-          iframe.title = `${track.title || 'Track'} on Wavlake`;
-          iframe.src = `https://embed.wavlake.com/track/${encodeURIComponent(track.track_id)}`;
-          iframe.width = '100%';
-          iframe.height = '380';
-          iframe.frameBorder = '0';
-          iframe.loading = 'lazy';
-          trackElement.appendChild(iframe);
-        }
-
-        const links = document.createElement('div');
-        links.classList.add('track-links');
-
-        const soundcloudLink = document.createElement('a');
-        soundcloudLink.href = SOUNDCLOUD_URL;
-        soundcloudLink.target = '_blank';
-        soundcloudLink.rel = 'noopener noreferrer';
-        soundcloudLink.textContent = 'Listen on SoundCloud';
-        links.appendChild(soundcloudLink);
-
-        const supportUrl = trackSupportUrl(track);
-        if (supportUrl) {
-          const wavlakeLink = document.createElement('a');
-          wavlakeLink.href = supportUrl;
-          wavlakeLink.target = '_blank';
-          wavlakeLink.rel = 'noopener noreferrer';
-          wavlakeLink.textContent = 'Support on Wavlake';
-          links.appendChild(wavlakeLink);
-        }
-
-        trackElement.appendChild(links);
-        songsSection.appendChild(trackElement);
-      });
+    if (tracks.length > 0) {
+      tracks.forEach(track => songsSection.appendChild(renderTrack(track || {})));
     } else {
-      songsSection.innerHTML = '<p class="fallback-copy">No Wavlake direct-support tracks are available right now. You can still listen and follow Fuzzed Records on <a href="https://soundcloud.com/fuzzedrecords" target="_blank" rel="noopener noreferrer">SoundCloud</a>.</p>';
+      songsSection.innerHTML = '<p class="fallback-copy">No Wavlake tracks are available right now. You can still listen on SoundCloud above.</p>';
     }
   } catch (err) {
     console.error('Error fetching tracks:', err);
-    songsSection.innerHTML = '<p class="fallback-copy">Wavlake tracks could not be loaded right now. Please listen on <a href="https://soundcloud.com/fuzzedrecords" target="_blank" rel="noopener noreferrer">SoundCloud</a> and check back later for direct-support links.</p>';
+    songsSection.innerHTML = '<p class="fallback-copy">Wavlake support links could not load right now. The SoundCloud player above is still available.</p>';
   }
 }
 

--- a/static/scripts/utils.js
+++ b/static/scripts/utils.js
@@ -1,20 +1,13 @@
 // utils.js - shared helper functions
 const PUBLIC_SECTIONS = ['listen', 'bands', 'submit', 'support', 'about'];
 
-// Highlight the active public navigation link and optionally scroll to a section.
-export function showSection(section) {
+// Highlight the active public navigation link without hiding content or replacing anchor behavior.
+export function highlightSection(section) {
   const targetSection = PUBLIC_SECTIONS.includes(section) ? section : 'listen';
   PUBLIC_SECTIONS.forEach(sec => {
-    const el = document.getElementById(sec);
     const btn = document.getElementById(`menu-${sec}`);
-    if (el) el.classList.toggle('active', sec === targetSection);
     if (btn) btn.classList.toggle('active', sec === targetSection);
   });
-
-  const el = document.getElementById(targetSection);
-  if (el) {
-    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }
 }
 
 export function getPublicSections() {

--- a/static/style.css
+++ b/static/style.css
@@ -217,7 +217,16 @@ h2 {
     margin-bottom: 6px;
 }
 
-.track-artist,
+.track-artwork {
+    border-radius: 12px;
+    display: block;
+    height: auto;
+    margin: 0 auto 14px;
+    max-width: min(100%, 320px);
+    width: 100%;
+}
+
+.track-meta,
 .fallback-copy {
     color: var(--muted);
     line-height: 1.6;


### PR DESCRIPTION
### Motivation
- Recenter the homepage around a SoundCloud-first listening experience and simplify the public journey to Listen → Bands → Submit → Support → About. 
- Remove per-track SoundCloud CTAs and demote advanced/creator features (Nostr/Alby/WebLN) to an advanced area while preserving backend integrations like `/tracks` and Wavlake support. 

### Description
- Reworked `static/scripts/tracks.js` to render Wavlake track cards with `title`, `artist`, `album` fallbacks, optional artwork, an embedded Wavlake player when `track_id` is present, and a single `Support on Wavlake` CTA while removing per-track SoundCloud links and adding friendlier loading/empty/error messages. 
- Replaced the JavaScript tab-switching flow with simple anchor navigation and limited JS that only highlights the active nav item by changing `showSection` → `highlightSection` in `static/scripts/utils.js` and updated `static/scripts/auth.js` to use the new helper and to guard the optional `menu-profile` handler. 
- Added CSS for track artwork and adjusted metadata styles in `static/style.css` to support the new Wavlake card layout. 
- Updated `README.md` to reflect a SoundCloud-first homepage, Wavlake direct support, band submission flow, and legacy `/fuzzedguitars` redirect behavior. 
- Preserved backend functionality and routes, including the `/tracks` endpoint and existing `app.py` legacy redirects to the homepage. 

### Testing
- Ran the project unit test suite with `pytest -q`, and all tests passed: `17 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3820213fec832784c627ff1b7801bc)