### PR TITLE
Refocus homepage on listening and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fuzzed Records
 
-Fuzzed Records is a simple independent music hub for noisy, guitar-driven bands. The public site emphasizes low-friction listening on **SoundCloud**, direct artist support through **Wavlake** where appropriate, band submissions, and a scoped **NIP-05** discovery endpoint via Azure AD for advanced identity use cases.
+Fuzzed Records is a simple independent music hub for noisy, guitar-driven music from the edges. The public site emphasizes low-friction listening on **SoundCloud**, a Wavlake-powered archive and direct-support layer where appropriate, future artist direction without open public submissions, and scoped **NIP-05** discovery via Azure AD for advanced identity use cases.
 
 ---
 
@@ -18,15 +18,16 @@ Fuzzed Records is a simple independent music hub for noisy, guitar-driven bands.
 
 ## Features
 
-- **Music Hub**: Stream featured Fuzzed Records tracks through a simple SoundCloud-first homepage experience.
-- **Direct Support**: Link listeners to Wavlake tracks for boosts and direct artist support.
-- **Band Submissions**: Provide a simple path for future bands to contact or submit music.
+- **Music Hub**: Stream Fuzzed Records through a simple SoundCloud-first homepage experience.
+- **Archive**: Preserve and present Fuzzed Records tracks using the existing Wavlake-powered `/tracks` integration.
+- **Direct Support**: Provide clear Wavlake boost/tip paths and explore direct Lightning tipping where production-ready.
+- **Future Bands**: Explain the future artist direction without opening public submissions yet.
 - **Nostr / Lightning**: Keep advanced identity and payment features available where useful, but not as the primary public journey.
 - **Responsive Design**: Optimized for both desktop and mobile devices.
 - **Efficient Data Caching**: Utilizes caching for optimizing data retrieval performance.
 - **Rate Limiting**: Protects API endpoints using Flask-Limiter with optional Azure Table Storage backend (ASGI-compatible).
 - **CORS Configuration**: Allowed origins can be customized via environment variable (Flask-CORS works under Hypercorn).
-- **Section Links**: Use URL hashes like `/#listen`, `/#bands`, `/#submit`, `/#support`, and `/#about` to open public sections directly. Legacy `/fuzzedguitars` traffic redirects to the homepage.
+- **Section Links**: Use URL hashes like `/#listen`, `/#archive`, `/#support`, `/#future-bands`, and `/#about` to jump through the public homepage. Legacy `/fuzzedguitars` traffic redirects to the homepage.
 
 ---
 

--- a/static/scripts/tracks.js
+++ b/static/scripts/tracks.js
@@ -7,12 +7,13 @@ function firstPresent(...values) {
 
 function trackSupportUrl(track) {
   return firstPresent(
-    track.url,
-    track.link,
     track.wavlake_url,
     track.wavlakeUrl,
-    track.media_url,
-    track.mediaUrl,
+    track.wavlake_track_url,
+    track.wavlakeTrackUrl,
+    track.url,
+    track.link,
+
   ) || (track.track_id ? `https://wavlake.com/track/${encodeURIComponent(track.track_id)}` : null);
 }
 
@@ -80,7 +81,7 @@ function renderTrack(track) {
     wavlakeLink.href = supportUrl;
     wavlakeLink.target = '_blank';
     wavlakeLink.rel = 'noopener noreferrer';
-    wavlakeLink.textContent = 'Support on Wavlake';
+    wavlakeLink.textContent = 'Boost on Wavlake';
     links.appendChild(wavlakeLink);
     trackElement.appendChild(links);
   }
@@ -92,7 +93,7 @@ export async function fetchTracks() {
   const songsSection = document.getElementById('songs-section');
   if (!songsSection) return;
 
-  songsSection.innerHTML = '<p class="fallback-copy">Loading Wavlake support links…</p>';
+  songsSection.innerHTML = '<p class="fallback-copy">Loading archive and support links…</p>';
 
   try {
     const response = await fetch('/tracks');
@@ -105,11 +106,11 @@ export async function fetchTracks() {
     if (tracks.length > 0) {
       tracks.forEach(track => songsSection.appendChild(renderTrack(track || {})));
     } else {
-      songsSection.innerHTML = '<p class="fallback-copy">No Wavlake tracks are available right now. You can still listen on SoundCloud above.</p>';
+      songsSection.innerHTML = '<p class="fallback-copy">No Wavlake archive tracks are available right now. You can still listen on SoundCloud above.</p>';
     }
   } catch (err) {
     console.error('Error fetching tracks:', err);
-    songsSection.innerHTML = '<p class="fallback-copy">Wavlake support links could not load right now. The SoundCloud player above is still available.</p>';
+    songsSection.innerHTML = '<p class="fallback-copy">Wavlake archive/support links could not load right now. The SoundCloud player above is still available.</p>';
   }
 }
 

--- a/static/scripts/utils.js
+++ b/static/scripts/utils.js
@@ -1,5 +1,5 @@
 // utils.js - shared helper functions
-const PUBLIC_SECTIONS = ['listen', 'bands', 'submit', 'support', 'about'];
+const PUBLIC_SECTIONS = ['listen', 'archive', 'support', 'future-bands', 'about'];
 
 // Highlight the active public navigation link without hiding content or replacing anchor behavior.
 export function highlightSection(section) {

--- a/static/style.css
+++ b/static/style.css
@@ -335,3 +335,43 @@ footer {
         padding: 22px 16px;
     }
 }
+
+.support-options {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    margin: 24px auto 0;
+    max-width: 860px;
+}
+
+.support-option {
+    background: white;
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    padding: 20px;
+    text-align: left;
+}
+
+.support-option p {
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+.muted-option {
+    background: rgba(255, 255, 255, 0.62);
+}
+
+@media (max-width: 640px) {
+    .menu {
+        border-radius: 24px;
+    }
+
+    .nav-btn,
+    .menu button {
+        flex: 1 1 140px;
+    }
+
+    .soundcloud-card iframe {
+        height: 360px;
+    }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,9 +17,9 @@
         </div>
         <nav class="menu" aria-label="Primary navigation">
             <a id="menu-listen" class="nav-btn active" href="#listen">Listen</a>
-            <a id="menu-bands" class="nav-btn" href="#bands">Bands</a>
-            <a id="menu-submit" class="nav-btn" href="#submit">Submit</a>
+            <a id="menu-archive" class="nav-btn" href="#archive">Archive</a>
             <a id="menu-support" class="nav-btn" href="#support">Support</a>
+            <a id="menu-future-bands" class="nav-btn" href="#future-bands">Future Bands</a>
             <a id="menu-about" class="nav-btn" href="#about">About</a>
         </nav>
     </header>
@@ -29,64 +29,74 @@
             <p class="eyebrow">Independent music from the edges</p>
             <h1 id="hero-title">Fuzzed Records</h1>
             <p class="hero-subtitle">Independent, noisy, guitar-driven music from the edges.</p>
-            <p class="hero-copy">Listen to the archive, follow future releases, submit your band, and support artists directly.</p>
+            <p class="hero-copy">Listen to the archive, follow future releases, and support artists directly.</p>
             <div class="cta-row">
                 <a class="button primary" href="#listen">Listen Now</a>
-                <a class="button" href="#submit">Submit Your Band</a>
-                <a class="button" href="#support">Support Artists</a>
+                <a class="button" href="#support">Tip / Support</a>
+                <a class="button" href="#about">About Fuzzed Records</a>
             </div>
         </section>
 
-        <section id="listen" class="content-section active" aria-labelledby="listen-title">
+        <section id="listen" class="content-section" aria-labelledby="listen-title">
             <div class="section-heading">
                 <p class="eyebrow">Listen</p>
                 <h2 id="listen-title">Start with SoundCloud</h2>
-                <p>Start here. Stream the Fuzzed Records archive and favorites on SoundCloud. Wavlake stays here for tracks where direct boosts and Bitcoin-native support are available.</p>
+                <p>Start here. Stream the Fuzzed Records archive on SoundCloud.</p>
             </div>
             <div class="soundcloud-card">
-                <iframe title="Fuzzed Favorites on SoundCloud" width="100%" height="450" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/fuzzedrecords/sets/fuzzedfavorites&color=%23ff5500&auto_play=false&hide_related=false&show_comments=false&show_user=true&show_reposts=false&show_teaser=true&visual=false"></iframe>
-                <a class="button primary" href="https://soundcloud.com/fuzzedrecords/sets/fuzzedfavorites" target="_blank" rel="noopener noreferrer">Open Fuzzed Favorites on SoundCloud</a>
+                <iframe title="Fuzzed Records on SoundCloud" width="100%" height="450" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/fuzzedrecords&color=%23ff5500&auto_play=false&hide_related=false&show_comments=false&show_user=true&show_reposts=false&show_teaser=true&visual=false"></iframe>
+                <a class="button primary" href="https://soundcloud.com/fuzzedrecords" target="_blank" rel="noopener noreferrer">Open Fuzzed Records on SoundCloud</a>
             </div>
+        </section>
 
+        <section id="archive" class="content-section" aria-labelledby="archive-title">
+            <div class="section-heading">
+                <p class="eyebrow">Archive / Artists</p>
+                <h2 id="archive-title">Fuzzed Records archive</h2>
+                <p>Wavlake powers the archive and direct-support layer for tracks where embedded playback, boost pages, or Bitcoin-native support links are available.</p>
+            </div>
             <div class="wavlake-block">
                 <h3>
-                    Direct-support tracks on
+                    Archive tracks on
                     <a href="https://wavlake.com" target="_blank" rel="noopener noreferrer">
                         <img src="https://wavlake.com/favicon.ico" alt="" class="external-logo">
                         Wavlake
                     </a>
                 </h3>
-                <p class="section-copy">When Wavlake tracks are available, use the embedded players below to listen and support artists directly.</p>
+                <p class="section-copy">Use the embedded players to listen here. When a real Wavlake track page is available, use the track action to boost or support through Wavlake.</p>
                 <div id="songs-section" aria-live="polite">
-                    <p class="fallback-copy">Checking Wavlake for direct-support tracks. If nothing loads, you can still listen on SoundCloud.</p>
+                    <p class="fallback-copy">Loading archive and support links…</p>
                 </div>
             </div>
-        </section>
-
-        <section id="bands" class="content-section" aria-labelledby="bands-title">
-            <div class="section-heading">
-                <p class="eyebrow">Bands</p>
-                <h2 id="bands-title">What fits here</h2>
-            </div>
-            <p>Fuzzed Records is looking for noisy, melodic, guitar-driven music with attitude, hooks, and a clear identity. Send demos, rehearsal recordings, live clips, or finished tracks.</p>
-        </section>
-
-        <section id="submit" class="content-section" aria-labelledby="submit-title">
-            <div class="section-heading">
-                <p class="eyebrow">Submit</p>
-                <h2 id="submit-title">Submit Your Band</h2>
-            </div>
-            <p>Send a short note, links to your music, where you are based, and what you are looking for.</p>
-            <a class="button primary" href="mailto:idmfrank@gmail.com?subject=Fuzzed%20Records%20band%20submission">Email a submission</a>
         </section>
 
         <section id="support" class="content-section" aria-labelledby="support-title">
             <div class="section-heading">
                 <p class="eyebrow">Support</p>
-                <h2 id="support-title">Support artists directly</h2>
+                <h2 id="support-title">Tip artists directly</h2>
             </div>
-            <p>Fuzzed Records uses Wavlake where it makes sense so listeners can boost tracks directly and help independent artists earn outside the normal streaming model.</p>
-            <p>Start by listening. If a Wavlake support link is available on a track, use it to send value straight to the music you care about.</p>
+            <p>Fuzzed Records uses Wavlake and Lightning where it makes sense so listeners can send small tips, boosts, or direct support to artists outside the normal streaming model.</p>
+            <div class="support-options">
+                <article class="support-option">
+                    <h3>Option A: Wavlake Boost</h3>
+                    <p>Open a Wavlake track page from the archive when one is available, then boost or support through Wavlake’s own listener tools.</p>
+                    <a class="button primary" href="#archive">Find Wavlake tracks</a>
+                </article>
+                <article class="support-option muted-option">
+                    <h3>Option B: Direct Lightning Tip</h3>
+                    <p>Direct Lightning tips are coming soon. Wallet, LNURL, Alby, Spark, and Nostr experiments remain available for future creator tooling, but they are not presented here as a production payment flow yet.</p>
+                </article>
+            </div>
+        </section>
+
+        <section id="future-bands" class="content-section" aria-labelledby="future-bands-title">
+            <div class="section-heading">
+                <p class="eyebrow">Future Bands</p>
+                <h2 id="future-bands-title">Future bands</h2>
+            </div>
+            <p>Fuzzed Records is building toward future releases and collaborations, but public submissions are not open yet. For now, the focus is the archive, the sound, and the direct-support model.</p>
+            <p>The direction is noisy, melodic, guitar-driven music with attitude, hooks, and a clear identity.</p>
+            <a class="button" href="https://soundcloud.com/fuzzedrecords" target="_blank" rel="noopener noreferrer">Follow for updates</a>
         </section>
 
         <section id="about" class="content-section" aria-labelledby="about-title">
@@ -94,15 +104,15 @@
                 <p class="eyebrow">About</p>
                 <h2 id="about-title">About Fuzzed Records</h2>
             </div>
-            <p>Fuzzed Records is an independent music project focused on noisy, guitar-driven bands, direct artist support, and simple ways for listeners to discover new music.</p>
+            <p>Fuzzed Records is an independent music project focused on noisy, guitar-driven bands, direct artist support, and simple ways for listeners to discover music.</p>
         </section>
 
         <section id="advanced" class="content-section advanced-section" aria-labelledby="advanced-title">
             <details>
                 <summary id="advanced-title">Creator Login / Advanced</summary>
+                <p class="fallback-copy">Advanced wallet and Nostr identity tools are retained for creator workflows and experiments, not as the main public listening path.</p>
                 <div id="alby-mvp" class="advanced-controls">
                     <button id="btn-connect-alby" style="display:none;">Connect Alby</button>
-                    <button id="btn-pay-test" style="display:none;">Pay Test Invoice (100 sats)</button>
                 </div>
                 <button id="menu-profile" class="text-button">Nostr Login</button>
                 <section id="profile-section">
@@ -124,32 +134,18 @@
     <script>
         window.serverWalletPubkey = "{{ serverWalletPubkey }}";
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
     <script>
-      (async () => {
+      (() => {
         const btnConnect = document.getElementById("btn-connect-alby");
-        const btnPay = document.getElementById("btn-pay-test");
-        if (!btnConnect || !btnPay || !window.WebLNHelper || !window.WebLNHelper.isAvailable()) return;
+        if (!btnConnect || !window.WebLNHelper || !window.WebLNHelper.isAvailable()) return;
         btnConnect.style.display = "inline-block";
         btnConnect.onclick = async () => {
           try {
             await window.WebLNHelper.enable();
-            btnPay.style.display = "inline-block";
-            alert("Alby connected!");
+            alert("Alby connected for advanced creator tooling.");
           } catch (e) {
             console.warn("Alby connect failed:", e);
             alert("Could not connect Alby (user cancelled or not available).");
-          }
-        };
-        btnPay.onclick = async () => {
-          try {
-            const inv = await window.WebLNHelper.makeInvoice(100, "Fuzzed Records test");
-            const pr = inv?.paymentRequest || inv;
-            await window.WebLNHelper.sendPayment(pr);
-            alert("Payment sent! Check your wallet.");
-          } catch (e) {
-            console.error("Payment error:", e);
-            alert("Payment failed or was cancelled.");
           }
         };
       })();


### PR DESCRIPTION
### Motivation
- Simplify the public homepage to be a SoundCloud-first music hub and to present Wavlake as an archive/direct-support layer rather than a primary listening path. 
- Remove public Gear/Submit UI and any test payment affordances so the main public journey centers on Listen → Archive → Support → Future Bands → About.
- Preserve backend integrations (`/tracks`, Wavlake, Nostr, Alby, Lightning experiments) while demoting advanced tooling to a secondary creator area.

### Description
- Reworked the homepage anchor navigation and hero CTAs in `templates/index.html` to use anchors `#listen`, `#archive`, `#support`, `#future-bands`, and `#about`, removed the public Submit/Bands/Gear CTAs, and added the SoundCloud embed as the primary listening entry. 
- Created a dedicated Archive section powered by the existing Wavlake front-end integration and moved Wavlake content/fallback copy into that section in `templates/index.html` and `static/scripts/tracks.js` (preserves `/tracks` usage). 
- Updated track rendering and copy in `static/scripts/tracks.js` to improve metadata fallbacks, prefer Wavlake-specific URLs, change CTA to `Boost on Wavlake`, and provide friendlier loading/empty/error states. 
- Demoted experimental wallet/Nostr functionality into an `Advanced / Creator Login` details block and removed the public `Pay Test Invoice (100 sats)` flow and related UI; removed the public QR script include and adjusted the in-page Alby connect behavior. 
- Replaced the old public section list in `static/scripts/utils.js` to match the new anchors and added support-section layout and mobile adjustments in `static/style.css`. 
- Updated `README.md` to reflect the SoundCloud-first listening focus, Wavlake archive/support positioning, and that public submissions are not open yet.

### Testing
- Ran the full test suite with `pytest -q`, which passed: `17 passed`.
- Performed a Python compile check with `python3 -m py_compile app.py wavlake_utils.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c111c5fb48327803644a9d17c4c6f)